### PR TITLE
Add `min_token_validity` variable in ClientCredentialsAuth object creation

### DIFF
--- a/firecrest/Authorization.py
+++ b/firecrest/Authorization.py
@@ -18,14 +18,17 @@ class ClientCredentialsAuth:
     :type client_secret: string
     :param token_uri: URI of the token request in the authorization server (e.g. https://auth.your-server.com/auth/realms/cscs/protocol/openid-connect/token)
     :type token_uri: string
+    :param min_token_validity: reuse OIDC token until {min_token_validity} sec before the expiration time (by default 10). Since the token will be checked by different microservices, setting more time in min_token_validity will ensure that the token doesn't expire in the middle of the request.
+    :type min_token_validity: float
     """
 
-    def __init__(self, client_id, client_secret, token_uri):
+    def __init__(self, client_id, client_secret, token_uri, min_token_validity=10):
         self._client_id = client_id
         self._client_secret = client_secret
         self._token_uri = token_uri
         self._access_token = None
         self._token_expiration_ts = None
+        self._min_token_validity = min_token_validity
 
     def get_access_token(self):
         """Returns an access token to be used for accessing resources.
@@ -34,12 +37,12 @@ class ClientCredentialsAuth:
         :rtype: string
         """
 
-        # Make sure that the access token has at least 10s left before
+        # Make sure that the access token has at least {min_token_validity} sec left before
         # it expires, otherwise make a new request
         if (
             self._access_token
             and self._token_expiration_ts
-            and time.time() <= (self._token_expiration_ts - 10)
+            and time.time() <= (self._token_expiration_ts - self._min_token_validity)
         ):
             return self._access_token
 

--- a/tests/test_authoriation.py
+++ b/tests/test_authoriation.py
@@ -1,0 +1,113 @@
+import httpretty
+import json
+import pytest
+
+from context import firecrest
+
+
+def auth_callback(request, uri, response_headers):
+    client_id = request.parsed_body["client_id"][0]
+    client_secret = request.parsed_body["client_secret"][0]
+    if client_id == "valid_id":
+        if client_secret == "valid_secret":
+            ret = {
+                "access_token": "token_1",
+                "expires_in": 15,
+                "refresh_expires_in": 0,
+                "token_type": "Bearer",
+                "not-before-policy": 0,
+                "scope": "profile firecrest email",
+            }
+            return [200, response_headers, json.dumps(ret)]
+        if client_secret == "valid_secret_2":
+            ret = {
+                "access_token": "token_2",
+                "expires_in": 15,
+                "refresh_expires_in": 0,
+                "token_type": "Bearer",
+                "not-before-policy": 0,
+                "scope": "profile firecrest email",
+            }
+            return [200, response_headers, json.dumps(ret)]
+        else:
+            ret = {
+                "error": "unauthorized_client",
+                "error_description": "Invalid client secret",
+            }
+            return [400, response_headers, json.dumps(ret)]
+    else:
+        ret = {
+            "error": "invalid_client",
+            "error_description": "Invalid client credentials",
+        }
+        return [400, response_headers, json.dumps(ret)]
+
+
+@pytest.fixture(autouse=True)
+def setup_callbacks():
+    httpretty.enable(allow_net_connect=False, verbose=True)
+
+    httpretty.register_uri(
+        httpretty.POST,
+        "https://myauth.com/auth/realms/cscs/protocol/openid-connect/token",
+        body=auth_callback,
+    )
+
+    yield
+
+    httpretty.disable()
+    httpretty.reset()
+
+
+def test_client_credentials_valid():
+    auth_obj = firecrest.ClientCredentialsAuth(
+        "valid_id",
+        "valid_secret",
+        "https://myauth.com/auth/realms/cscs/protocol/openid-connect/token",
+    )
+    assert auth_obj._min_token_validity == 10
+    assert auth_obj.get_access_token() == "token_1"
+    # Change the secret differentiate between first and second request
+    auth_obj._client_secret = "valid_secret_2"
+    assert auth_obj.get_access_token() == "token_1"
+
+    auth_obj = firecrest.ClientCredentialsAuth(
+        "valid_id",
+        "valid_secret",
+        "https://myauth.com/auth/realms/cscs/protocol/openid-connect/token",
+        min_token_validity=20,
+    )
+    assert auth_obj.get_access_token() == "token_1"
+    # Change the secret differentiate between first and second request
+    auth_obj._client_secret = "valid_secret_2"
+    assert auth_obj.get_access_token() == "token_2"
+
+
+def test_client_credentials_invalid_id():
+    auth_obj = firecrest.ClientCredentialsAuth(
+        "invalid_id",
+        "valid_secret",
+        "https://myauth.com/auth/realms/cscs/protocol/openid-connect/token",
+    )
+    with pytest.raises(Exception) as exc_info:
+        auth_obj.get_access_token()
+
+    assert (
+        str(exc_info.value)
+        == "Request to https://myauth.com/auth/realms/cscs/protocol/openid-connect/token failed with status code 400: {'error': 'invalid_client', 'error_description': 'Invalid client credentials'}"
+    )
+
+
+def test_client_credentials_invalid_secret():
+    auth_obj = firecrest.ClientCredentialsAuth(
+        "valid_id",
+        "invalid_secret",
+        "https://myauth.com/auth/realms/cscs/protocol/openid-connect/token",
+    )
+    with pytest.raises(Exception) as exc_info:
+        auth_obj.get_access_token()
+
+    assert (
+        str(exc_info.value)
+        == "Request to https://myauth.com/auth/realms/cscs/protocol/openid-connect/token failed with status code 400: {'error': 'unauthorized_client', 'error_description': 'Invalid client secret'}"
+    )

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -184,7 +184,7 @@ def sacct_callback(request, uri, response_headers):
             "task_url": "TASK_IP/tasks/acct_full_id",
         }
         status_code = 200
-    elif jobs == ['empty']:
+    elif jobs == ["empty"]:
         ret = {
             "success": "Task created",
             "task_id": "acct_empty_id",
@@ -865,7 +865,7 @@ def test_poll(valid_client):
             "user": "username",
         }
     ]
-    assert valid_client.poll(machine="cluster1", jobs=['empty']) == []
+    assert valid_client.poll(machine="cluster1", jobs=["empty"]) == []
 
 
 def test_poll_invalid_arguments(valid_client):


### PR DESCRIPTION
The `ClientCredentialsAuth` will reuse the last OIDC token until `min_token_validity` seconds before the expiration time. The JWT token will be travel (and be checked) in many microservices so it makes sense to give some more time in order to make sure that it doesn't expire in the middle of the operation.

@jpdorsch do you think 10 seconds are enough or should I set more time as a default?