### PR TITLE
Handle better the failed requests in ClientCredentialsAuth

### DIFF
--- a/firecrest/Authorization.py
+++ b/firecrest/Authorization.py
@@ -7,6 +7,8 @@
 import requests
 import time
 
+from requests.compat import json
+
 
 class ClientCredentialsAuth:
     """
@@ -53,7 +55,11 @@ class ClientCredentialsAuth:
             "client_secret": self._client_secret,
         }
         resp = requests.post(self._token_uri, headers=headers, data=data)
-        resp_json = resp.json()
+        try:
+            resp_json = resp.json()
+        except json.JSONDecodeError:
+            resp_json = ""
+
         if not resp.ok:
             raise Exception(
                 f"Request to {self._token_uri} failed with "


### PR DESCRIPTION
Now pyfirecrest will still raise an error but it will be easier to understand what the problem is. The new output will be something like this:
```bash
Traceback (most recent call last):
...
  File ".../pyfirecrest/firecrest/Authorization.py", line 65, in get_access_token
    f"Request to {self._token_uri} failed with "
Exception: Request to AUTH_URL/.../protocol/openid-connect/token failed with status code 503:
```