### PR TITLE
Replace poetry with a standard PEP 621 builder

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,17 +18,13 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.x'
-    - name: Install dependencies
+        python-version: '3.8'
+    - name: install flit
       run: |
-        python -m pip install --upgrade pip poetry
-        poetry --version
-        poetry check --no-interaction
-        poetry config virtualenvs.create false
-        poetry install --with test --no-interaction
-    - name: Publish to PyPI
+        pip install flit~=3.4
+    - name: Build and publish
+      run: |
+        flit publish
       env:
-        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      run: |
-        poetry config pypi-token.pypi $PYPI_TOKEN
-        poetry publish --build --no-interaction
+        FLIT_USERNAME: __token__
+        FLIT_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,18 +22,15 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip poetry
-        poetry --version
-        poetry check --no-interaction
-        poetry config virtualenvs.create false
-        poetry install --with test --no-interaction
+        python -m pip install --upgrade pip
+        pip install .[test]
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        poetry run flake8 . --count --select=E9,F63,F7,F82,F821 --show-source --statistics
+        flake8 . --count --select=E9,F63,F7,F82,F821 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       working-directory: ./tests
       run: |
-        poetry run pytest -v
+        pytest -v

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,9 +8,9 @@ version: 2
 python:
   version: "3.8"
   install:
-      - method: pip
-        path: .
-        extra_requirements:
+    - method: pip
+      path: .
+      extra_requirements:
         - docs
 
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,18 +5,13 @@
 # Required
 version: 2
 
-build:
-  os: ubuntu-20.04
-  tools:
-    python: "3.7"
-  jobs:
-    pre_create_environment:
-      - asdf plugin add poetry
-      - asdf install poetry latest
-      - asdf global poetry latest
-      - poetry config virtualenvs.create false
-    post_install:
-      - poetry install
+python:
+  version: "3.8"
+  install:
+      - method: pip
+        path: .
+        extra_requirements:
+        - docs
 
 sphinx:
   configuration: docs/source/conf.py

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,22 +13,14 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../..'))
-
+import firecrest
 
 # -- Project information -----------------------------------------------------
 
 project = 'PyFirecREST'
 copyright = '2022, CSCS Swiss National Supercomputing Center'
 author = 'CSCS Swiss National Supercomputing Center'
-
-# The full version, including alpha/beta/rc tags
-version_py = os.path.join(os.path.dirname(__file__), '../..', 'firecrest', 'version.py')
-version_d = {}
-with open(version_py) as fp:
-    exec(fp.read(), version_d)
-
-release = version_d['VERSION']
-
+release = firecrest.__version__
 
 # -- General configuration ---------------------------------------------------
 

--- a/firecrest/__init__.py
+++ b/firecrest/__init__.py
@@ -5,10 +5,9 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 #
 import sys
-from firecrest.version import VERSION
 
 
-__version__ = VERSION
+__version__ = "1.3.0"
 __app_name__ = "firecrest"
 MIN_PYTHON_VERSION = (3, 7, 0)
 

--- a/firecrest/version.py
+++ b/firecrest/version.py
@@ -1,9 +1,0 @@
-#
-#  Copyright (c) 2019-2022, ETH Zurich. All rights reserved.
-#
-#  Please, refer to the LICENSE file in the root directory.
-#  SPDX-License-Identifier: BSD-3-Clause
-#
-from . import __version__
-
-VERSION = __version__

--- a/firecrest/version.py
+++ b/firecrest/version.py
@@ -4,4 +4,6 @@
 #  Please, refer to the LICENSE file in the root directory.
 #  SPDX-License-Identifier: BSD-3-Clause
 #
-VERSION = "1.3.0"
+from . import __version__
+
+VERSION = __version__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,48 +1,49 @@
-[tool.poetry]
+[build-system]
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
+
+[tool.flit.module]
+name = "firecrest"
+
+[project]
 name = "pyfirecrest"
-version = "1.3.0"
+dynamic = ["version"]
 description = "pyFirecrest is a python wrapper for FirecREST"
-authors = ["CSCS"]
-license = "BSD-3-Clause"
+authors = [{name = "CSCS Swiss National Supercomputing Center"}]
 maintainers = [
-    "Eirini Koutsaniti <eirini.koutsaniti@cscs.ch>",
-    "Juan Pablo Dorsch <juanpablo.dorsch@cscs.ch>"
+    {name = "Eirini Koutsaniti", email = "eirini.koutsaniti@cscs.ch"},
+    {name = "Juan Pablo Dorsch", email = "juanpablo.dorsch@cscs.ch"}
 ]
 readme = "README.md"
-homepage = "https://pyfirecrest.readthedocs.io"
-documentation = "https://pyfirecrest.readthedocs.io"
-repository = "https://github.com/eth-cscs/pyfirecrest"
-packages = [
-    { include = "firecrest" }
+license = {file = "LICENSE"}
+classifiers = [
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+]
+requires-python = ">=3.7"
+dependencies = [
+    "requests>=2.14.0", 
+    "PyJWT>=2.4.0",
+    "typer~=0.7.0",
 ]
 
-[tool.poetry.scripts]
-firecrest = 'firecrest.cli_script:main'
+[project.urls]
+Homepage = "https://pyfirecrest.readthedocs.io"
+Documentation = "https://pyfirecrest.readthedocs.io"
+Repository = "https://github.com/eth-cscs/pyfirecrest"
 
-
-[tool.poetry.dependencies]
-python = "^3.7"
-requests = ">=2.14.0"
-PyJWT = ">=2.4.0"
-typer = {extras = ["all"], version = "^0.7.0"}
-
-[tool.poetry.group.test]
-optional = true
-
-[tool.poetry.group.test.dependencies]
-httpretty = ">=1.0.3"
-pytest = ">=5.3"
-flake8 = "^5.0"
-
-[tool.poetry.group.docs]
-optional = true
-
-[tool.poetry.group.docs.dependencies]
-myst-parser = ">=0.16"
-sphinx = ">=4.0"
-sphinx-autobuild = ">=2021.0"
-sphinx-rtd-theme = ">=1.0"
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+[project.optional-dependencies]
+test = [
+    "httpretty>=1.0.3",
+    "pytest>=5.3",
+    "flake8~=5.0",
+]
+docs = [
+    "sphinx>=4.0",
+    "sphinx-rtd-theme>=1.0",
+    "myst-parser>=0.16",
+    "sphinx-autobuild>=2021.0",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ Homepage = "https://pyfirecrest.readthedocs.io"
 Documentation = "https://pyfirecrest.readthedocs.io"
 Repository = "https://github.com/eth-cscs/pyfirecrest"
 
+[project.scripts]
+firecrest = "firecrest.cli_script:main"
+
 [project.optional-dependencies]
 test = [
     "httpretty>=1.0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.7"
 dependencies = [
     "requests>=2.14.0", 
     "PyJWT>=2.4.0",
-    "typer~=0.7.0",
+    "typer[all]~=0.7.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
As mentioned in https://github.com/eth-cscs/pyfirecrest/pull/31#issuecomment-1385361866,
poetry does not support modern build standards for Python packages (https://www.python.org/dev/peps/pep-0621/), making it difficult to work with.

This PR replaces it with flit, allowing:

1. Reading the version from the package, rather than having it duplicated in two places
2. Simplification of the github and readthedocs workflows

Note, equally you could use https://github.com/pypa/flit, https://github.com/pypa/hatch or https://github.com/pdm-project/pdm/ as the builder