### PR TITLE
Add support for the head and tail endpoints

### DIFF
--- a/firecrest/BasicClient.py
+++ b/firecrest/BasicClient.py
@@ -812,8 +812,68 @@ class Firecrest:
         )
         return self._json_response([resp], 200)["output"]
 
+    def head(self, machine, target_path, bytes=None, lines=None):
+        """Display the beginning of a specified file.
+        By default 10 lines will be returned.
+        Bytes and lines cannot be specified simultaneously.
+        The final result will be smaller than `UTILITIES_MAX_FILE_SIZE` bytes.
+        This variable is available in the parameters command.
+
+        :param machine: the machine name where the filesystem belongs to
+        :type machine: string
+        :param target_path: the absolute target path
+        :type target_path: string
+        :param lines: the number of lines to be displayed
+        :type lines: integer, optional
+        :param bytes: the number of bytes to be displayed
+        :type bytes: integer, optional
+        :calls: GET `/utilities/head`
+        :rtype: string
+        """
+        resp = self._get_request(
+            endpoint="/utilities/head",
+            additional_headers={"X-Machine-Name": machine},
+            params={
+                "targetPath": target_path,
+                "lines": lines,
+                "bytes": bytes,
+            },
+        )
+        return self._json_response([resp], 200)["output"]
+
+    def tail(self, machine, target_path, bytes=None, lines=None):
+        """Display the last part of a specified file.
+        By default 10 lines will be returned.
+        Bytes and lines cannot be specified simultaneously.
+        The final result will be smaller than `UTILITIES_MAX_FILE_SIZE` bytes.
+        This variable is available in the parameters command.
+
+        :param machine: the machine name where the filesystem belongs to
+        :type machine: string
+        :param target_path: the absolute target path
+        :type target_path: string
+        :param lines: the number of lines to be displayed
+        :type lines: integer, optional
+        :param bytes: the number of bytes to be displayed
+        :type bytes: integer, optional
+        :calls: GET `/utilities/head`
+        :rtype: string
+        """
+        resp = self._get_request(
+            endpoint="/utilities/tail",
+            additional_headers={"X-Machine-Name": machine},
+            params={
+                "targetPath": target_path,
+                "lines": lines,
+                "bytes": bytes,
+            },
+        )
+        return self._json_response([resp], 200)["output"]
+
     def view(self, machine, target_path):
         """View the content of a specified file.
+        The final result will be smaller than `UTILITIES_MAX_FILE_SIZE` bytes.
+        This variable is available in the parameters command.
 
         :param machine: the machine name where the filesystem belongs to
         :type machine: string

--- a/firecrest/cli/__init__.py
+++ b/firecrest/cli/__init__.py
@@ -515,14 +515,52 @@ def head(
         ..., help="The machine name where the filesystem belongs to."
     ),
     path: str = typer.Argument(..., help="The absolute target path."),
+    lines: str = typer.Option(None, "-n", "--lines", help="Print count lines of each of the specified files."),
+    bytes: str = typer.Option(None, "-c", "--bytes", help="Print bytes of each of the specified files."),
 ):
-    """View the content of a specified file
+    """Display the beginning of a specified file.
+    By default the first 10 lines will be returned.
+    Bytes and lines cannot be specified simultaneously.
 
     You view only files smaller than UTILITIES_MAX_FILE_SIZE bytes.
     This variable is available in the parameters command.
     """
+    if lines and bytes:
+        console.print(
+            f"[red]{__app_name__} head: cannot specify both 'bytes' and 'lines'[/red]"
+        )
+        raise typer.Exit(code=1)
+
     try:
-        console.print(client.view(machine, path))
+        console.print(client.head(machine, path, bytes, lines))
+    except Exception as e:
+        examine_exeption(e)
+        raise typer.Exit(code=1)
+
+@app.command(rich_help_panel="Utilities commands")
+def tail(
+    machine: str = typer.Argument(
+        ..., help="The machine name where the filesystem belongs to."
+    ),
+    path: str = typer.Argument(..., help="The absolute target path."),
+    lines: str = typer.Option(None, "-n", "--lines", help="Print count lines of each of the specified files."),
+    bytes: str = typer.Option(None, "-c", "--bytes", help="Print bytes of each of the specified files."),
+):
+    """Display the end of a specified file.
+    By default the last 10 lines will be returned.
+    Bytes and lines cannot be specified simultaneously.
+
+    You view only files smaller than UTILITIES_MAX_FILE_SIZE bytes.
+    This variable is available in the parameters command.
+    """
+    if lines and bytes:
+        console.print(
+            f"[red]{__app_name__} tail: cannot specify both 'bytes' and 'lines'[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        console.print(client.tail(machine, path, bytes, lines))
     except Exception as e:
         examine_exeption(e)
         raise typer.Exit(code=1)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1252,7 +1252,7 @@ def test_tail(valid_client):
     assert valid_client.tail("cluster1", "/path/to/file", bytes=5) == "ello\n"
 
 
-def test_cli_head(valid_credentials):
+def test_cli_tail(valid_credentials):
     args = valid_credentials + ["tail", "cluster1", "/path/to/file"]
     result = runner.invoke(cli.app, args=args)
     stdout = common.clean_stdout(result.stdout)


### PR DESCRIPTION
An important change is that the `head` command of the cli will now use the `head` endpoint, instead of `view`.