### PR TITLE
Add documentation for cli in readthedocs page

### DIFF
--- a/docs/source/cli_reference.rst
+++ b/docs/source/cli_reference.rst
@@ -1,0 +1,8 @@
+Command-line Interface
+======================
+
+CLI reference
+*************
+.. click:: firecrest.cli:typer_click_object
+   :prog: firecrest
+   :nested: full

--- a/docs/source/cli_reference.rst
+++ b/docs/source/cli_reference.rst
@@ -1,6 +1,9 @@
 Command-line Interface
 ======================
 
+The best way to try the cli and see its capabilities is with the ``--help`` option in every subcommand.
+You can also find here a complete list of the subcommands, options and arguments.
+
 CLI reference
 *************
 .. click:: firecrest.cli:typer_click_object

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ release = firecrest.__version__
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc']
+extensions = ['sphinx.ext.autodoc', 'sphinx_click']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,7 @@ You can also clone it from `Github <https://github.com/eth-cscs/pyfirecrest>`__ 
    authorization
    tutorial
    reference
+   cli_reference
 
 Contact
 =======

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -274,36 +274,38 @@ CLI support
 
 After version 1.3.0, pyFirecREST comes together with a CLI but for now it can only be used with the `f7t.ClientCredentialsAuth` authentication class.
 
-You will need to set the environment variables `FIRECREST_CLIENT_ID`, `FIRECREST_CLIENT_SECRET` and `AUTH_TOKEN_URL` to set up the Client Credentials client, as well as `FIRECREST_URL` with the URL for the FirecREST instance you are using.
+You will need to set the environment variables ``FIRECREST_CLIENT_ID``, ``FIRECREST_CLIENT_SECRET`` and ``AUTH_TOKEN_URL`` to set up the Client Credentials client, as well as ``FIRECREST_URL`` with the URL for the FirecREST instance you are using.
 
 After that you can explore the capabilities of the CLI with the `--help` option:
-```bash
-firecrest --help
-firecrest ls --help
-firecrest submit --help
-firecrest upload --help
-firecrest download --help
-firecrest submit-template --help
-```
+
+.. code-block:: bash
+
+    firecrest --help
+    firecrest ls --help
+    firecrest submit --help
+    firecrest upload --help
+    firecrest download --help
+    firecrest submit-template --help
 
 Some basic examples:
-```bash
-# Get the available systems
-firecrest systems
 
-# Get the parameters of different microservices of FirecREST
-firecrest parameters
+.. code-block:: bash
 
-# List files of directory
-firecrest ls cluster1 /home
+    # Get the available systems
+    firecrest systems
 
-# Submit a job
-firecrest submit cluster script.sh
+    # Get the parameters of different microservices of FirecREST
+    firecrest parameters
 
-# Upload a "small" file (you can check the maximum size in `UTILITIES_MAX_FILE_SIZE` from the `parameters` command)
-firecrest upload --type=direct cluster local_file.txt /path/to/cluster/fs
+    # List files of directory
+    firecrest ls cluster1 /home
 
-# Upload a "large" file
-firecrest upload --type=external cluster local_file.txt /path/to/cluster/fs
-# You will have to finish the upload with a second command that will be given in the output
-```
+    # Submit a job
+    firecrest submit cluster script.sh
+
+    # Upload a "small" file (you can check the maximum size in `UTILITIES_MAX_FILE_SIZE` from the `parameters` command)
+    firecrest upload --type=direct cluster local_file.txt /path/to/cluster/fs
+
+    # Upload a "large" file
+    firecrest upload --type=external cluster local_file.txt /path/to/cluster/fs
+    # You will have to finish the upload with a second command that will be given in the output

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -268,3 +268,42 @@ Here is an example of the code that will handle those failures.
         # You might also get regular exceptions in some cases. For example when you are
         # trying to upload a file that doesn't exist in your local filesystem.
         pass
+
+CLI support
+-----------
+
+After version 1.3.0, pyFirecREST comes together with a CLI but for now it can only be used with the `f7t.ClientCredentialsAuth` authentication class.
+
+You will need to set the environment variables `FIRECREST_CLIENT_ID`, `FIRECREST_CLIENT_SECRET` and `AUTH_TOKEN_URL` to set up the Client Credentials client, as well as `FIRECREST_URL` with the URL for the FirecREST instance you are using.
+
+After that you can explore the capabilities of the CLI with the `--help` option:
+```bash
+firecrest --help
+firecrest ls --help
+firecrest submit --help
+firecrest upload --help
+firecrest download --help
+firecrest submit-template --help
+```
+
+Some basic examples:
+```bash
+# Get the available systems
+firecrest systems
+
+# Get the parameters of different microservices of FirecREST
+firecrest parameters
+
+# List files of directory
+firecrest ls cluster1 /home
+
+# Submit a job
+firecrest submit cluster script.sh
+
+# Upload a "small" file (you can check the maximum size in `UTILITIES_MAX_FILE_SIZE` from the `parameters` command)
+firecrest upload --type=direct cluster local_file.txt /path/to/cluster/fs
+
+# Upload a "large" file
+firecrest upload --type=external cluster local_file.txt /path/to/cluster/fs
+# You will have to finish the upload with a second command that will be given in the output
+```

--- a/firecrest/cli/__init__.py
+++ b/firecrest/cli/__init__.py
@@ -1153,3 +1153,5 @@ def main(
             format="%(message)s",
             handlers=[RichHandler(console=console)],
         )
+
+typer_click_object = typer.main.get_command(app)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ docs = [
     "sphinx-rtd-theme>=1.0",
     "myst-parser>=0.16",
     "sphinx-autobuild>=2021.0",
+    "sphinx-click==3.0.2"
 ]
 
 [tool.mypy]


### PR DESCRIPTION
To see the docs page, you can go to the branch
```
# checkout to the branch
# better install in an environment
pip install '.[docs]'
cd docs
make html
cd build/html
python -m http.server
```