### PR TITLE
Support `skip_ending` and `skip_beginning` arguments in tail and head commands 

### DIFF
--- a/firecrest/BasicClient.py
+++ b/firecrest/BasicClient.py
@@ -895,7 +895,7 @@ class Firecrest:
         target_path: str,
         bytes: Optional[int] = None,
         lines: Optional[int] = None,
-        reverse: Optional[bool] = False,
+        skip_ending: Optional[bool] = False,
     ) -> str:
         """Display the beginning of a specified file.
         By default 10 lines will be returned.
@@ -907,12 +907,18 @@ class Firecrest:
         :param target_path: the absolute target path
         :param lines: the number of lines to be displayed
         :param bytes: the number of bytes to be displayed
+        :param skip_ending: the output will be the whole file, without the last NUM bytes/lines of each file. NUM should be specified in the respective argument through `bytes` or `lines`. Equivalent to passing -NUM to the `head` command.
         :calls: GET `/utilities/head`
         """
         resp = self._get_request(
             endpoint="/utilities/head",
             additional_headers={"X-Machine-Name": machine},
-            params={"targetPath": target_path, "lines": lines, "bytes": bytes, "reverse": reverse},
+            params={
+                "targetPath": target_path,
+                "lines": lines,
+                "bytes": bytes,
+                "skip_ending": skip_ending,
+            },
         )
         return self._json_response([resp], 200)["output"]
 
@@ -922,7 +928,7 @@ class Firecrest:
         target_path: str,
         bytes: Optional[int] = None,
         lines: Optional[int] = None,
-        reverse: Optional[bool] = False,
+        skip_beginning: Optional[bool] = False,
     ) -> str:
         """Display the last part of a specified file.
         By default 10 lines will be returned.
@@ -934,12 +940,18 @@ class Firecrest:
         :param target_path: the absolute target path
         :param lines: the number of lines to be displayed
         :param bytes: the number of bytes to be displayed
+        :param skip_beginning: the output will start with byte/line NUM of each file. NUM should be specified in the respective argument through `bytes` or `lines`. Equivalent to passing +NUM to the `tail` command.
         :calls: GET `/utilities/head`
         """
         resp = self._get_request(
             endpoint="/utilities/tail",
             additional_headers={"X-Machine-Name": machine},
-            params={"targetPath": target_path, "lines": lines, "bytes": bytes, "reverse": reverse},
+            params={
+                "targetPath": target_path,
+                "lines": lines,
+                "bytes": bytes,
+                "skip_beginning": skip_beginning,
+            },
         )
         return self._json_response([resp], 200)["output"]
 

--- a/firecrest/BasicClient.py
+++ b/firecrest/BasicClient.py
@@ -893,8 +893,8 @@ class Firecrest:
         self,
         machine: str,
         target_path: str,
-        bytes: Optional[int] = None,
-        lines: Optional[int] = None,
+        bytes: Optional[str] = None,
+        lines: Optional[str] = None,
         skip_ending: Optional[bool] = False,
     ) -> str:
         """Display the beginning of a specified file.
@@ -926,8 +926,8 @@ class Firecrest:
         self,
         machine: str,
         target_path: str,
-        bytes: Optional[int] = None,
-        lines: Optional[int] = None,
+        bytes: Optional[str] = None,
+        lines: Optional[str] = None,
         skip_beginning: Optional[bool] = False,
     ) -> str:
         """Display the last part of a specified file.

--- a/firecrest/BasicClient.py
+++ b/firecrest/BasicClient.py
@@ -870,6 +870,7 @@ class Firecrest:
         target_path: str,
         bytes: Optional[int] = None,
         lines: Optional[int] = None,
+        reverse: Optional[bool] = False,
     ) -> str:
         """Display the beginning of a specified file.
         By default 10 lines will be returned.
@@ -886,7 +887,7 @@ class Firecrest:
         resp = self._get_request(
             endpoint="/utilities/head",
             additional_headers={"X-Machine-Name": machine},
-            params={"targetPath": target_path, "lines": lines, "bytes": bytes},
+            params={"targetPath": target_path, "lines": lines, "bytes": bytes, "reverse": reverse},
         )
         return self._json_response([resp], 200)["output"]
 
@@ -896,6 +897,7 @@ class Firecrest:
         target_path: str,
         bytes: Optional[int] = None,
         lines: Optional[int] = None,
+        reverse: Optional[bool] = False,
     ) -> str:
         """Display the last part of a specified file.
         By default 10 lines will be returned.
@@ -912,7 +914,7 @@ class Firecrest:
         resp = self._get_request(
             endpoint="/utilities/tail",
             additional_headers={"X-Machine-Name": machine},
-            params={"targetPath": target_path, "lines": lines, "bytes": bytes},
+            params={"targetPath": target_path, "lines": lines, "bytes": bytes, "reverse": reverse},
         )
         return self._json_response([resp], 200)["output"]
 

--- a/firecrest/cli/__init__.py
+++ b/firecrest/cli/__init__.py
@@ -602,7 +602,7 @@ def tail(
         if lines and lines.startswith("+"):
             lines_arg = lines[1:]
             skip_beginning = True
-        elif bytes and bytes.startswith("-"):
+        elif bytes and bytes.startswith("+"):
             bytes_arg = bytes[1:]
             skip_beginning = True
 

--- a/firecrest/cli/__init__.py
+++ b/firecrest/cli/__init__.py
@@ -522,6 +522,9 @@ def head(
     bytes: int = typer.Option(
         None, "-c", "--bytes", help="Print bytes of each of the specified files."
     ),
+    reverse: bool = typer.Option(
+        False, help="Print bytes of each of the specified files."
+    ),
 ):
     """Display the beginning of a specified file.
     By default the first 10 lines will be returned.
@@ -537,7 +540,7 @@ def head(
         raise typer.Exit(code=1)
 
     try:
-        console.print(client.head(machine, path, bytes, lines))
+        console.print(client.head(machine, path, bytes, lines, reverse))
     except Exception as e:
         examine_exeption(e)
         raise typer.Exit(code=1)
@@ -555,6 +558,9 @@ def tail(
     bytes: int = typer.Option(
         None, "-c", "--bytes", help="Print bytes of each of the specified files."
     ),
+    reverse: bool = typer.Option(
+        False, help="Print bytes of each of the specified files."
+    ),
 ):
     """Display the end of a specified file.
     By default the last 10 lines will be returned.
@@ -570,7 +576,7 @@ def tail(
         raise typer.Exit(code=1)
 
     try:
-        console.print(client.tail(machine, path, bytes, lines))
+        console.print(client.tail(machine, path, bytes, lines, reverse))
     except Exception as e:
         examine_exeption(e)
         raise typer.Exit(code=1)

--- a/firecrest/cli/__init__.py
+++ b/firecrest/cli/__init__.py
@@ -516,14 +516,19 @@ def head(
         ..., help="The machine name where the filesystem belongs to."
     ),
     path: str = typer.Argument(..., help="The absolute target path."),
-    lines: int = typer.Option(
-        None, "-n", "--lines", help="Print count lines of each of the specified files."
+    lines: str = typer.Option(
+        None,
+        "-n",
+        "--lines",
+        help="Print count lines of each of the specified files; with a leading '-', print all but the last NUM lines of each file",
+        metavar="[-]NUM",
     ),
-    bytes: int = typer.Option(
-        None, "-c", "--bytes", help="Print bytes of each of the specified files."
-    ),
-    reverse: bool = typer.Option(
-        False, help="Print bytes of each of the specified files."
+    bytes: str = typer.Option(
+        None,
+        "-c",
+        "--bytes",
+        help="Print bytes of each of the specified files; with a leading '-', print all but the last NUM bytes of each file",
+        metavar="[-]NUM",
     ),
 ):
     """Display the beginning of a specified file.
@@ -540,7 +545,17 @@ def head(
         raise typer.Exit(code=1)
 
     try:
-        console.print(client.head(machine, path, bytes, lines, reverse))
+        lines_arg = lines
+        bytes_arg = bytes
+        skip_ending = False
+        if lines and lines.startswith("-"):
+            lines_arg = lines[1:]
+            skip_ending = True
+        elif bytes:
+            bytes_arg = bytes[1:]
+            skip_ending = True
+
+        console.print(client.head(machine, path, bytes_arg, lines_arg, skip_ending))
     except Exception as e:
         examine_exeption(e)
         raise typer.Exit(code=1)
@@ -552,14 +567,19 @@ def tail(
         ..., help="The machine name where the filesystem belongs to."
     ),
     path: str = typer.Argument(..., help="The absolute target path."),
-    lines: int = typer.Option(
-        None, "-n", "--lines", help="Print count lines of each of the specified files."
+    lines: str = typer.Option(
+        None,
+        "-n",
+        "--lines",
+        help="output the last NUM lines; or use +NUM to output starting with line NUM",
+        metavar="[+]NUM",
     ),
-    bytes: int = typer.Option(
-        None, "-c", "--bytes", help="Print bytes of each of the specified files."
-    ),
-    reverse: bool = typer.Option(
-        False, help="Print bytes of each of the specified files."
+    bytes: str = typer.Option(
+        None,
+        "-c",
+        "--bytes",
+        help="output the last NUM bytes; or use +NUM to output starting with byte NUM",
+        metavar="[+]NUM",
     ),
 ):
     """Display the end of a specified file.
@@ -576,7 +596,17 @@ def tail(
         raise typer.Exit(code=1)
 
     try:
-        console.print(client.tail(machine, path, bytes, lines, reverse))
+        lines_arg = lines
+        bytes_arg = bytes
+        skip_beginning = False
+        if lines and lines.startswith("+"):
+            lines_arg = lines[1:]
+            skip_beginning = True
+        elif bytes:
+            bytes_arg = bytes[1:]
+            skip_beginning = True
+
+        console.print(client.tail(machine, path, bytes_arg, lines_arg, skip_beginning))
     except Exception as e:
         examine_exeption(e)
         raise typer.Exit(code=1)
@@ -1108,7 +1138,7 @@ def main(
     api_version: str = typer.Option(
         None,
         help="Set the version of the api of firecrest. By default it will be assumed that you are using version 1.13.0 or "
-             "compatible. The version is parsed by the `packaging` library.",
+        "compatible. The version is parsed by the `packaging` library.",
         envvar="FIRECREST_API_VERSION",
     ),
     verbose: Optional[bool] = typer.Option(
@@ -1159,5 +1189,6 @@ def main(
             format="%(message)s",
             handlers=[RichHandler(console=console)],
         )
+
 
 typer_click_object = typer.main.get_command(app)

--- a/firecrest/cli/__init__.py
+++ b/firecrest/cli/__init__.py
@@ -520,14 +520,14 @@ def head(
         None,
         "-n",
         "--lines",
-        help="Print count lines of each of the specified files; with a leading '-', print all but the last NUM lines of each file",
+        help="Print NUM lines of each of the specified files; with a leading '-', print all but the last NUM lines of each file",
         metavar="[-]NUM",
     ),
     bytes: str = typer.Option(
         None,
         "-c",
         "--bytes",
-        help="Print bytes of each of the specified files; with a leading '-', print all but the last NUM bytes of each file",
+        help="Print NUM bytes of each of the specified files; with a leading '-', print all but the last NUM bytes of each file",
         metavar="[-]NUM",
     ),
 ):
@@ -551,7 +551,7 @@ def head(
         if lines and lines.startswith("-"):
             lines_arg = lines[1:]
             skip_ending = True
-        elif bytes:
+        elif bytes and bytes.startswith("-"):
             bytes_arg = bytes[1:]
             skip_ending = True
 
@@ -571,14 +571,14 @@ def tail(
         None,
         "-n",
         "--lines",
-        help="output the last NUM lines; or use +NUM to output starting with line NUM",
+        help="Output the last NUM lines; or use +NUM to output starting with line NUM",
         metavar="[+]NUM",
     ),
     bytes: str = typer.Option(
         None,
         "-c",
         "--bytes",
-        help="output the last NUM bytes; or use +NUM to output starting with byte NUM",
+        help="Output the last NUM bytes; or use +NUM to output starting with byte NUM",
         metavar="[+]NUM",
     ),
 ):
@@ -602,7 +602,7 @@ def tail(
         if lines and lines.startswith("+"):
             lines_arg = lines[1:]
             skip_beginning = True
-        elif bytes:
+        elif bytes and bytes.startswith("-"):
             bytes_arg = bytes[1:]
             skip_beginning = True
 


### PR DESCRIPTION
The arguments `skip_ending` and `skip_beginning` are not yet deployed in tds. 