### PR TITLE
Fix small bugs in the async client

### DIFF
--- a/firecrest/BasicClient.py
+++ b/firecrest/BasicClient.py
@@ -677,8 +677,8 @@ class Firecrest:
 
         :param machine: the machine name where the filesystem belongs to
         :param target_path: the absolute target path
-        :param lines: the number of lines to be displayed
         :param bytes: the number of bytes to be displayed
+        :param lines: the number of lines to be displayed
         :param skip_ending: the output will be the whole file, without the last NUM bytes/lines of each file. NUM should be specified in the respective argument through `bytes` or `lines`. Equivalent to passing -NUM to the `head` command.
         :calls: GET `/utilities/head`
         """
@@ -710,8 +710,8 @@ class Firecrest:
 
         :param machine: the machine name where the filesystem belongs to
         :param target_path: the absolute target path
-        :param lines: the number of lines to be displayed
         :param bytes: the number of bytes to be displayed
+        :param lines: the number of lines to be displayed
         :param skip_beginning: the output will start with byte/line NUM of each file. NUM should be specified in the respective argument through `bytes` or `lines`. Equivalent to passing +NUM to the `tail` command.
         :calls: GET `/utilities/head`
         """


### PR DESCRIPTION
Fixes:
- After the rate limit for a microservice is reached, the next request should be scheduled after the `Retry-After` header and the user-imposed rate limit. Both should be respected so we keep the larger value.
- Change `bytes` and `lines` to `str` (instead of `int`) in the `head` and `tail` commands in the async client, to follow the sync client. In the sync client this was already fixed.
- Add `skip_ending` and `skip_beginning` in `head` and `tail` commands respectively, in the async client.
- Changed the order of `bytes`and `lines` arguments in the documentation of `head` and `tail` commands, to follow the order of the arguments in the function.