### PR TITLE
Merge GET requests to `/tasks`,`/compute/jobs` and `/compute/acct` in the async client 

### DIFF
--- a/firecrest/AsyncClient.py
+++ b/firecrest/AsyncClient.py
@@ -381,19 +381,14 @@ class AsyncFirecrest:
         """
         task_ids = [] if task_ids is None else task_ids
         responses = [] if responses is None else responses
-        endpoint = "/tasks/"
-        if len(task_ids) == 1:
-            endpoint += task_ids[0]
+        endpoint = "/tasks"
+        params = {}
+        if task_ids:
+            params = {"tasks": ",".join([str(j) for j in task_ids])}
 
-        resp = await self._get_request(endpoint=endpoint)
+        resp = await self._get_request(endpoint=endpoint, params=params)
         responses.append(resp)
-        taskinfo = self._json_response(responses, 200)
-        if len(task_ids) == 0:
-            return taskinfo["tasks"]
-        elif len(task_ids) == 1:
-            return {task_ids[0]: taskinfo["task"]}
-        else:
-            return {k: v for k, v in taskinfo["tasks"].items() if k in task_ids}
+        return self._json_response(responses, 200)["tasks"]
 
     async def _task_safe(
         self, task_id: str, responses: Optional[List[requests.Response]] = None

--- a/firecrest/AsyncExternalStorage.py
+++ b/firecrest/AsyncExternalStorage.py
@@ -33,8 +33,7 @@ logger = logging.getLogger(__name__)
 
 
 class AsyncExternalStorage:
-    """External storage object.
-    """
+    """External storage object."""
 
     _final_states: set[str]
 
@@ -55,14 +54,12 @@ class AsyncExternalStorage:
 
     @property
     def client(self) -> AsyncFirecrest:
-        """Returns the client that will be used to get information for the task.
-        """
+        """Returns the client that will be used to get information for the task."""
         return self._client
 
     @property
     def task_id(self) -> str:
-        """Returns the FirecREST task ID that is associated with this transfer.
-        """
+        """Returns the FirecREST task ID that is associated with this transfer."""
         return self._task_id
 
     async def _update(self) -> None:

--- a/firecrest/BasicClient.py
+++ b/firecrest/BasicClient.py
@@ -31,6 +31,7 @@ else:
 
 logger = logging.getLogger(__name__)
 
+
 # This function is temporarily here
 def handle_response(response):
     print("\nResponse status code:")

--- a/firecrest/BasicClient.py
+++ b/firecrest/BasicClient.py
@@ -278,30 +278,22 @@ class Firecrest:
         responses: Optional[List[requests.Response]] = None,
     ) -> dict[str, t.Task]:
         """Return a dictionary of FirecREST tasks and their last update.
-        When `task_ids` is an empty list or contains more than one element the
-        `/tasks` endpoint will be called. Otherwise `/tasks/{taskid}`.
-        When the `/tasks` is called the method will not give an error for invalid IDs,
-        but `/tasks/{taskid}` will raise an exception.
+        The result will only contain entries for valid tasks and the rest will be ignored.
 
         :param task_ids: list of task IDs. When empty all tasks are returned.
         :param responses: list of responses that are associated with these tasks (only relevant for error)
-        :calls: GET `/tasks` or `/tasks/{taskid}`
+        :calls: GET `/tasks`
         """
         task_ids = [] if task_ids is None else task_ids
         responses = [] if responses is None else responses
-        endpoint = "/tasks/"
-        if len(task_ids) == 1:
-            endpoint += task_ids[0]
+        endpoint = "/tasks"
+        params = {}
+        if task_ids:
+            params = {"tasks": ",".join([str(j) for j in task_ids])}
 
-        resp = self._get_request(endpoint=endpoint)
+        resp = self._get_request(endpoint=endpoint, params=params)
         responses.append(resp)
-        taskinfo = self._json_response(responses, 200)
-        if len(task_ids) == 0:
-            return taskinfo["tasks"]
-        elif len(task_ids) == 1:
-            return {task_ids[0]: taskinfo["task"]}
-        else:
-            return {k: v for k, v in taskinfo["tasks"].items() if k in task_ids}
+        return self._json_response(responses, 200)["tasks"]
 
     def _task_safe(
         self, task_id: str, responses: Optional[List[requests.Response]] = None

--- a/firecrest/ExternalStorage.py
+++ b/firecrest/ExternalStorage.py
@@ -35,8 +35,7 @@ logger = logging.getLogger(__name__)
 
 
 class ExternalStorage:
-    """External storage object.
-    """
+    """External storage object."""
 
     _final_states: set[str]
 
@@ -58,14 +57,12 @@ class ExternalStorage:
 
     @property
     def client(self) -> Firecrest:
-        """Returns the client that will be used to get information for the task.
-        """
+        """Returns the client that will be used to get information for the task."""
         return self._client
 
     @property
     def task_id(self) -> str:
-        """Returns the FirecREST task ID that is associated with this transfer.
-        """
+        """Returns the FirecREST task ID that is associated with this transfer."""
         return self._task_id
 
     def _update(self) -> None:

--- a/firecrest/FirecrestException.py
+++ b/firecrest/FirecrestException.py
@@ -21,8 +21,7 @@ ERROR_HEADERS = {
 
 
 class FirecrestException(Exception):
-    """Base class for exceptions raised when using PyFirecREST.
-    """
+    """Base class for exceptions raised when using PyFirecREST."""
 
     def __init__(self, responses):
         super().__init__()
@@ -42,32 +41,28 @@ class FirecrestException(Exception):
 
 
 class NotFound(FirecrestException):
-    """Exception raised by an invalid path
-    """
+    """Exception raised by an invalid path"""
 
     def __str__(self):
         return f"{super().__str__()}: FirecREST endpoint not found"
 
 
 class UnauthorizedException(FirecrestException):
-    """Exception raised by an unauthorized request
-    """
+    """Exception raised by an unauthorized request"""
 
     def __str__(self):
         return f"{super().__str__()}: unauthorized request"
 
 
 class ClientsCredentialsException(FirecrestException):
-    """Exception raised by the request to the authorization server
-    """
+    """Exception raised by the request to the authorization server"""
 
     def __str__(self):
         return f"{super().__str__()}: Client credentials error"
 
 
 class HeaderException(FirecrestException):
-    """Exception raised by a request with an error header
-    """
+    """Exception raised by a request with an error header"""
 
     def __str__(self):
         s = f"{super().__str__()}: "
@@ -80,8 +75,7 @@ class HeaderException(FirecrestException):
 
 
 class UnexpectedStatusException(FirecrestException):
-    """Exception raised when a request gets an unexpected status
-    """
+    """Exception raised when a request gets an unexpected status"""
 
     def __init__(self, responses, expected_status_code):
         super().__init__(responses)
@@ -92,18 +86,15 @@ class UnexpectedStatusException(FirecrestException):
 
 
 class NoJSONException(FirecrestException):
-    """Exception raised when JSON in not included in the response
-    """
+    """Exception raised when JSON in not included in the response"""
 
     def __str__(self):
         return f"{super().__str__()}: JSON is not included in the response"
 
 
 class StorageDownloadException(FirecrestException):
-    """Exception raised by a failed external download
-    """
+    """Exception raised by a failed external download"""
 
 
 class StorageUploadException(FirecrestException):
-    """Exception raised by a failed external upload
-    """
+    """Exception raised by a failed external upload"""

--- a/firecrest/cli/__init__.py
+++ b/firecrest/cli/__init__.py
@@ -82,7 +82,7 @@ def examine_exeption(e: Exception) -> None:
 
 def create_table(table_title, data, *mappings):
     table = Table(title=table_title, box=box.ASCII)
-    for (title, _) in mappings:
+    for title, _ in mappings:
         table.add_column(title, overflow="fold")
 
     for i in data:
@@ -103,8 +103,7 @@ def services(
         None, "-n", "--name", help="Get information for only one service."
     )
 ):
-    """Provides information for the services of FirecREST
-    """
+    """Provides information for the services of FirecREST"""
     try:
         if name:
             result = [client.service(name)]
@@ -132,8 +131,7 @@ def systems(
         None, "-n", "--name", help="Get information for only one system."
     )
 ):
-    """Provides information for the available systems in FirecREST
-    """
+    """Provides information for the available systems in FirecREST"""
     try:
         if name:
             result = [client.system(name)]
@@ -157,8 +155,7 @@ def systems(
 
 @app.command(rich_help_panel="Status commands")
 def parameters():
-    """Configurable parameters of FirecREST
-    """
+    """Configurable parameters of FirecREST"""
     try:
         result = client.parameters()
         storage_table = create_table(
@@ -192,8 +189,7 @@ def tasks(
         True, help="Display the output in a pager application."
     ),
 ):
-    """Retrieve information about the FirecREST tasks of the users
-    """
+    """Retrieve information about the FirecREST tasks of the users"""
     try:
         result = client._tasks(taskids)
         num_results = len(result.values())
@@ -238,8 +234,7 @@ def ls(
     ),
     raw: bool = typer.Option(False, "--raw", help="Print unformatted."),
 ):
-    """List directory contents
-    """
+    """List directory contents"""
     try:
         result = client.list_files(system, path, show_hidden)
         if raw:
@@ -280,8 +275,7 @@ def mkdir(
         help="Create intermediate directories as required, equivalent to `-p` of the unix command.",
     ),
 ):
-    """Create new directories
-    """
+    """Create new directories"""
     try:
         client.mkdir(system, path, p)
     except Exception as e:
@@ -301,8 +295,7 @@ def mv(
     source: str = typer.Argument(..., help="The absolute source path."),
     destination: str = typer.Argument(..., help="The absolute destination path."),
 ):
-    """Rename/move files, directory, or symlink at the `source_path` to the `target_path` on `system`'s filesystem
-    """
+    """Rename/move files, directory, or symlink at the `source_path` to the `target_path` on `system`'s filesystem"""
     try:
         client.mv(system, source, destination)
     except Exception as e:
@@ -322,8 +315,7 @@ def chmod(
     path: str = typer.Argument(..., help="The absolute target path."),
     mode: str = typer.Argument(..., help="Same as numeric mode of linux chmod tool."),
 ):
-    """Change the file mod bits of a given file according to the specified mode
-    """
+    """Change the file mod bits of a given file according to the specified mode"""
     try:
         client.chmod(system, path, mode)
     except Exception as e:
@@ -367,8 +359,7 @@ def cp(
     source: str = typer.Argument(..., help="The absolute source path."),
     destination: str = typer.Argument(..., help="The absolute destination path."),
 ):
-    """Copy files
-    """
+    """Copy files"""
     try:
         client.copy(system, source, destination)
     except Exception as e:
@@ -387,8 +378,7 @@ def file(
     ),
     path: str = typer.Argument(..., help="The absolute target path."),
 ):
-    """Determine file type
-    """
+    """Determine file type"""
     try:
         console.print(client.file_type(system, path))
     except Exception as e:
@@ -409,8 +399,7 @@ def stat(
     deref: bool = typer.Option(False, "-L", "--dereference", help="Follow links."),
     raw: bool = typer.Option(False, "--raw", help="Print unformatted."),
 ):
-    """Use the stat linux application to determine the status of a file on the system's filesystem
-    """
+    """Use the stat linux application to determine the status of a file on the system's filesystem"""
     try:
         result = client.stat(system, path, deref)
         if raw:
@@ -498,8 +487,7 @@ def symlink(
     target: str = typer.Argument(..., help="The path of the original file."),
     link_name: str = typer.Argument(..., help="The name of the link to the TARGET."),
 ):
-    """Create a symbolic link
-    """
+    """Create a symbolic link"""
     try:
         client.symlink(system, target, link_name)
     except Exception as e:
@@ -524,8 +512,7 @@ def rm(
     ),
     # TODO (?) add option to not display error to emulate `-f` from the rm command
 ):
-    """Remove directory entries
-    """
+    """Remove directory entries"""
     try:
         if force:
             client.simple_delete(system, path)
@@ -547,8 +534,7 @@ def checksum(
     ),
     path: str = typer.Argument(..., help="The absolute target path."),
 ):
-    """Calculate the SHA256 (256-bit) checksum
-    """
+    """Calculate the SHA256 (256-bit) checksum"""
     try:
         console.print(client.checksum(system, path))
     except Exception as e:
@@ -823,8 +809,7 @@ def submit(
         help="The batch file can be local (default) or on the system's filesystem.",
     ),
 ):
-    """Submit a batch script to the workload manger of the target system
-    """
+    """Submit a batch script to the workload manger of the target system"""
     try:
         console.print(client.submit(system, job_script, local, account=account))
     except Exception as e:
@@ -863,8 +848,7 @@ def submit_mv(
         """,
     ),
 ):
-    """Move/rename file
-    """
+    """Move/rename file"""
     try:
         console.print(
             client.submit_move_job(
@@ -907,8 +891,7 @@ def submit_cp(
         """,
     ),
 ):
-    """Copy file
-    """
+    """Copy file"""
     try:
         console.print(
             client.submit_copy_job(
@@ -951,8 +934,7 @@ def submit_rsync(
         """,
     ),
 ):
-    """Transfer/synchronize files or directories efficiently between filesystems
-    """
+    """Transfer/synchronize files or directories efficiently between filesystems"""
     try:
         console.print(
             client.submit_rsync_job(
@@ -994,8 +976,7 @@ def submit_rm(
         """,
     ),
 ):
-    """Remove files
-    """
+    """Remove files"""
     try:
         console.print(
             client.submit_delete_job(system, path, job_name, time, jobid, account)
@@ -1096,8 +1077,7 @@ def cancel(
     ),
     job: str = typer.Argument(..., help="The ID of the job that will be cancelled."),
 ):
-    """Cancel job
-    """
+    """Cancel job"""
     try:
         client.cancel(system, job)
     except Exception as e:
@@ -1111,8 +1091,7 @@ def list(
         ..., "-s", "--system", help="The name of the system.", envvar="FIRECREST_SYSTEM"
     ),
 ):
-    """List all active reservations and their status
-    """
+    """List all active reservations and their status"""
     try:
         res = client.all_reservations(system)
         console.print(res)
@@ -1141,8 +1120,7 @@ def create(
         ..., help="The end time for reservation (YYYY-MM-DDTHH:MM:SS)."
     ),
 ):
-    """Create a reservation
-    """
+    """Create a reservation"""
     try:
         client.create_reservation(
             system, name, account, num_nodes, node_type, start_time, end_time
@@ -1172,8 +1150,7 @@ def update(
         ..., help="The end time for reservation (YYYY-MM-DDTHH:MM:SS)."
     ),
 ):
-    """Update a reservation
-    """
+    """Update a reservation"""
     try:
         client.update_reservation(
             system, name, account, num_nodes, node_type, start_time, end_time
@@ -1190,8 +1167,7 @@ def delete(
     ),
     name: str = typer.Argument(..., help="The reservation name."),
 ):
-    """Delete a reservation
-    """
+    """Delete a reservation"""
     try:
         client.delete_reservation(system, name)
     except Exception as e:

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -209,7 +209,7 @@ def queue_handler(request: Request):
             "task_url": "TASK_IP/tasks/queue_full_id",
         }
         status_code = 200
-    elif jobs == ["352", "2", "334"]:
+    elif set(jobs) == {"352", "2", "334"}:
         ret = {
             "success": "Task created",
             "task_id": "queue_352_2_334_id",
@@ -271,7 +271,7 @@ def sacct_handler(request: Request):
             "task_url": "TASK_IP/tasks/acct_empty_id",
         }
         status_code = 200
-    elif jobs == ["352", "2", "334"]:
+    elif set(jobs) == {"352", "2", "334"}:
         ret = {
             "success": "Task created",
             "task_id": "acct_352_2_334_id",

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -368,12 +368,8 @@ def tasks_handler(request: Request):
     global queue_retry
     global cancel_retry
 
-    uri = request.url
-    taskid = uri.split("/")[-1]
-    if taskid == "tasks":
-        # TODO: return all tasks
-        pass
-    elif taskid in (
+    taskid = request.args.get("tasks")
+    if taskid in (
         "submit_path_job_id_default_account",
         "submit_path_job_id_proj_account",
         "submit_path_job_id_fail",
@@ -381,16 +377,18 @@ def tasks_handler(request: Request):
         if submit_path_retry < submit_path_result:
             submit_path_retry += 1
             ret = {
-                "task": {
-                    "data": "https://127.0.0.1:5003",
-                    "description": "Queued",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-04T11:52:10",
-                    "service": "compute",
-                    "status": "100",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": "https://127.0.0.1:5003",
+                        "description": "Queued",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-04T11:52:10",
+                        "service": "compute",
+                        "status": "100",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
@@ -402,39 +400,43 @@ def tasks_handler(request: Request):
                 35335405 if taskid == "submit_path_job_id_default_account" else 35335406
             )
             ret = {
-                "task": {
-                    "data": {
-                        "job_data_err": "",
-                        "job_data_out": "",
-                        "job_file": "/path/to/workdir/script.sh",
-                        "job_file_err": "/path/to/workdir/slurm-35335405.out",
-                        "job_file_out": "/path/to/workdir/slurm-35335405.out",
-                        "jobid": jobid,
-                        "result": "Job submitted",
-                    },
-                    "description": "Finished successfully",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-04T11:52:11",
-                    "service": "compute",
-                    "status": "200",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": {
+                            "job_data_err": "",
+                            "job_data_out": "",
+                            "job_file": "/path/to/workdir/script.sh",
+                            "job_file_err": "/path/to/workdir/slurm-35335405.out",
+                            "job_file_out": "/path/to/workdir/slurm-35335405.out",
+                            "jobid": jobid,
+                            "result": "Job submitted",
+                        },
+                        "description": "Finished successfully",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-04T11:52:11",
+                        "service": "compute",
+                        "status": "200",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
         else:
             ret = {
-                "task": {
-                    "data": "sbatch: error: This does not look like a batch script...",
-                    "description": "Finished with errors",
-                    "hash_id": "taskid",
-                    "last_modify": "2021-12-04T11:52:11",
-                    "service": "compute",
-                    "status": "400",
-                    "task_id": "taskid",
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": "sbatch: error: This does not look like a batch script...",
+                        "description": "Finished with errors",
+                        "hash_id": "taskid",
+                        "last_modify": "2021-12-04T11:52:11",
+                        "service": "compute",
+                        "status": "400",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
@@ -446,16 +448,18 @@ def tasks_handler(request: Request):
         if submit_upload_retry < submit_upload_result:
             submit_upload_retry += 1
             ret = {
-                "task": {
-                    "data": "Queued",
-                    "description": "Queued",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-04T11:52:10",
-                    "service": "compute",
-                    "status": "100",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": "Queued",
+                        "description": "Queued",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-04T11:52:10",
+                        "service": "compute",
+                        "status": "100",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
@@ -469,39 +473,43 @@ def tasks_handler(request: Request):
                 else 35342668
             )
             ret = {
-                "task": {
-                    "data": {
-                        "job_data_err": "",
-                        "job_data_out": "",
-                        "job_file": f"/path/to/firecrest/{taskid}/script.sh",
-                        "job_file_err": f"/path/to/firecrest/{taskid}/slurm-35342667.out",
-                        "job_file_out": f"/path/to/firecrest/{taskid}/slurm-35342667.out",
-                        "jobid": jobid,
-                        "result": "Job submitted",
-                    },
-                    "description": "Finished successfully",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-04T11:52:11",
-                    "service": "compute",
-                    "status": "200",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": {
+                            "job_data_err": "",
+                            "job_data_out": "",
+                            "job_file": f"/path/to/firecrest/{taskid}/script.sh",
+                            "job_file_err": f"/path/to/firecrest/{taskid}/slurm-35342667.out",
+                            "job_file_out": f"/path/to/firecrest/{taskid}/slurm-35342667.out",
+                            "jobid": jobid,
+                            "result": "Job submitted",
+                        },
+                        "description": "Finished successfully",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-04T11:52:11",
+                        "service": "compute",
+                        "status": "200",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
         else:
             ret = {
-                "task": {
-                    "data": "sbatch: error: This does not look like a batch script...",
-                    "description": "Finished with errors",
-                    "hash_id": "taskid",
-                    "last_modify": "2021-12-04T11:52:11",
-                    "service": "compute",
-                    "status": "400",
-                    "task_id": "taskid",
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": "sbatch: error: This does not look like a batch script...",
+                        "description": "Finished with errors",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-04T11:52:11",
+                        "service": "compute",
+                        "status": "400",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
@@ -514,114 +522,124 @@ def tasks_handler(request: Request):
         if acct_retry < acct_result:
             acct_retry += 1
             ret = {
-                "task": {
-                    "data": "Queued",
-                    "description": "Queued",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-04T11:52:10",
-                    "service": "compute",
-                    "status": "100",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": "Queued",
+                        "description": "Queued",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-04T11:52:10",
+                        "service": "compute",
+                        "status": "100",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
         elif taskid == "acct_352_2_334_id":
             ret = {
-                "task": {
-                    "data": [
-                        {
-                            "jobid": "352",
-                            "name": "firecrest_job_test",
-                            "nodelist": "nid0[6227-6229]",
-                            "nodes": "3",
-                            "partition": "normal",
-                            "start_time": "2021-11-29T16:31:07",
-                            "state": "COMPLETED",
-                            "time": "00:48:00",
-                            "time_left": "2021-11-29T16:31:47",
-                            "user": "username",
-                        },
-                        {
-                            "jobid": "334",
-                            "name": "firecrest_job_test2",
-                            "nodelist": "nid02401",
-                            "nodes": "1",
-                            "partition": "normal",
-                            "start_time": "2021-11-29T16:31:07",
-                            "state": "COMPLETED",
-                            "time": "00:17:12",
-                            "time_left": "2021-11-29T16:31:50",
-                            "user": "username",
-                        },
-                    ],
-                    "description": "Finished successfully",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-06T09:53:48",
-                    "service": "compute",
-                    "status": "200",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": [
+                            {
+                                "jobid": "352",
+                                "name": "firecrest_job_test",
+                                "nodelist": "nid0[6227-6229]",
+                                "nodes": "3",
+                                "partition": "normal",
+                                "start_time": "2021-11-29T16:31:07",
+                                "state": "COMPLETED",
+                                "time": "00:48:00",
+                                "time_left": "2021-11-29T16:31:47",
+                                "user": "username",
+                            },
+                            {
+                                "jobid": "334",
+                                "name": "firecrest_job_test2",
+                                "nodelist": "nid02401",
+                                "nodes": "1",
+                                "partition": "normal",
+                                "start_time": "2021-11-29T16:31:07",
+                                "state": "COMPLETED",
+                                "time": "00:17:12",
+                                "time_left": "2021-11-29T16:31:50",
+                                "user": "username",
+                            },
+                        ],
+                        "description": "Finished successfully",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-06T09:53:48",
+                        "service": "compute",
+                        "status": "200",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
         elif taskid == "acct_full_id":
             ret = {
-                "task": {
-                    "data": [
-                        {
-                            "jobid": "352",
-                            "name": "firecrest_job_test",
-                            "nodelist": "nid0[6227-6229]",
-                            "nodes": "3",
-                            "partition": "normal",
-                            "start_time": "2021-11-29T16:31:07",
-                            "state": "COMPLETED",
-                            "time": "00:48:00",
-                            "time_left": "2021-11-29T16:31:47",
-                            "user": "username",
-                        }
-                    ],
-                    "description": "Finished successfully",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-06T09:53:48",
-                    "service": "compute",
-                    "status": "200",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": [
+                            {
+                                "jobid": "352",
+                                "name": "firecrest_job_test",
+                                "nodelist": "nid0[6227-6229]",
+                                "nodes": "3",
+                                "partition": "normal",
+                                "start_time": "2021-11-29T16:31:07",
+                                "state": "COMPLETED",
+                                "time": "00:48:00",
+                                "time_left": "2021-11-29T16:31:47",
+                                "user": "username",
+                            }
+                        ],
+                        "description": "Finished successfully",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-06T09:53:48",
+                        "service": "compute",
+                        "status": "200",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
         elif taskid == "acct_empty_id":
             ret = {
-                "task": {
-                    "data": {},
-                    "description": "Finished successfully",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-06T09:53:48",
-                    "service": "compute",
-                    "status": "200",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": {},
+                        "description": "Finished successfully",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-06T09:53:48",
+                        "service": "compute",
+                        "status": "200",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
         else:
             ret = {
-                "task": {
-                    "data": "sacct: fatal: Bad job/step specified: l",
-                    "description": "Finished with errors",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-06T09:47:22",
-                    "service": "compute",
-                    "status": "400",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": "sacct: fatal: Bad job/step specified: l",
+                        "description": "Finished with errors",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-06T09:47:22",
+                        "service": "compute",
+                        "status": "400",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
@@ -633,114 +651,122 @@ def tasks_handler(request: Request):
         if queue_retry < queue_result:
             queue_retry += 1
             ret = {
-                "task": {
-                    "data": "Queued",
-                    "description": "Queued",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-04T11:52:10",
-                    "service": "compute",
-                    "status": "100",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": "Queued",
+                        "description": "Queued",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-04T11:52:10",
+                        "service": "compute",
+                        "status": "100",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
         elif taskid == "queue_352_2_334_id":
             ret = {
-                "task": {
-                    "data": {
-                        "0": {
-                            "job_data_err": "",
-                            "job_data_out": "",
-                            "job_file": "(null)",
-                            "job_file_err": "stderr-file-not-found",
-                            "job_file_out": "stdout-file-not-found",
-                            "jobid": "352",
-                            "name": "interactive",
-                            "nodelist": "nid02357",
-                            "nodes": "1",
-                            "partition": "debug",
-                            "start_time": "6:38",
-                            "state": "RUNNING",
-                            "time": "2022-03-10T10:11:34",
-                            "time_left": "23:22",
-                            "user": "username",
-                        }
-                    },
-                    "description": "Finished successfully",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-06T09:53:48",
-                    "service": "compute",
-                    "status": "200",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": {
+                            "0": {
+                                "job_data_err": "",
+                                "job_data_out": "",
+                                "job_file": "(null)",
+                                "job_file_err": "stderr-file-not-found",
+                                "job_file_out": "stdout-file-not-found",
+                                "jobid": "352",
+                                "name": "interactive",
+                                "nodelist": "nid02357",
+                                "nodes": "1",
+                                "partition": "debug",
+                                "start_time": "6:38",
+                                "state": "RUNNING",
+                                "time": "2022-03-10T10:11:34",
+                                "time_left": "23:22",
+                                "user": "username",
+                            }
+                        },
+                        "description": "Finished successfully",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-06T09:53:48",
+                        "service": "compute",
+                        "status": "200",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
         elif taskid == "queue_full_id":
             ret = {
-                "task": {
-                    "data": {
-                        "0": {
-                            "job_data_err": "",
-                            "job_data_out": "",
-                            "job_file": "(null)",
-                            "job_file_err": "stderr-file-not-found",
-                            "job_file_out": "stdout-file-not-found",
-                            "jobid": "352",
-                            "name": "interactive",
-                            "nodelist": "nid02357",
-                            "nodes": "1",
-                            "partition": "debug",
-                            "start_time": "6:38",
-                            "state": "RUNNING",
-                            "time": "2022-03-10T10:11:34",
-                            "time_left": "23:22",
-                            "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": {
+                            "0": {
+                                "job_data_err": "",
+                                "job_data_out": "",
+                                "job_file": "(null)",
+                                "job_file_err": "stderr-file-not-found",
+                                "job_file_out": "stdout-file-not-found",
+                                "jobid": "352",
+                                "name": "interactive",
+                                "nodelist": "nid02357",
+                                "nodes": "1",
+                                "partition": "debug",
+                                "start_time": "6:38",
+                                "state": "RUNNING",
+                                "time": "2022-03-10T10:11:34",
+                                "time_left": "23:22",
+                                "user": "username",
+                            },
+                            "1": {
+                                "job_data_err": "",
+                                "job_data_out": "",
+                                "job_file": "(null)",
+                                "job_file_err": "stderr-file-not-found",
+                                "job_file_out": "stdout-file-not-found",
+                                "jobid": "356",
+                                "name": "interactive",
+                                "nodelist": "nid02351",
+                                "nodes": "1",
+                                "partition": "debug",
+                                "start_time": "6:38",
+                                "state": "RUNNING",
+                                "time": "2022-03-10T10:11:34",
+                                "time_left": "23:22",
+                                "user": "username",
+                            },
                         },
-                        "1": {
-                            "job_data_err": "",
-                            "job_data_out": "",
-                            "job_file": "(null)",
-                            "job_file_err": "stderr-file-not-found",
-                            "job_file_out": "stdout-file-not-found",
-                            "jobid": "356",
-                            "name": "interactive",
-                            "nodelist": "nid02351",
-                            "nodes": "1",
-                            "partition": "debug",
-                            "start_time": "6:38",
-                            "state": "RUNNING",
-                            "time": "2022-03-10T10:11:34",
-                            "time_left": "23:22",
-                            "user": "username",
-                        },
-                    },
-                    "description": "Finished successfully",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-06T09:53:48",
-                    "service": "compute",
-                    "status": "200",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                        "description": "Finished successfully",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-06T09:53:48",
+                        "service": "compute",
+                        "status": "200",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
         else:
             ret = {
-                "task": {
-                    "data": "slurm_load_jobs error: Invalid job id specified",
-                    "description": "Finished with errors",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-06T09:47:22",
-                    "service": "compute",
-                    "status": "400",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": "slurm_load_jobs error: Invalid job id specified",
+                        "description": "Finished with errors",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-06T09:47:22",
+                        "service": "compute",
+                        "status": "400",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
@@ -752,61 +778,69 @@ def tasks_handler(request: Request):
         if cancel_retry < cancel_result:
             cancel_retry += 1
             ret = {
-                "task": {
-                    "data": "Queued",
-                    "description": "Queued",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-04T11:52:10",
-                    "service": "compute",
-                    "status": "100",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": "Queued",
+                        "description": "Queued",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-04T11:52:10",
+                        "service": "compute",
+                        "status": "100",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
         elif taskid == "cancel_job_id":
             ret = {
-                "task": {
-                    "data": "",
-                    "description": "Finished successfully",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-06T10:42:06",
-                    "service": "compute",
-                    "status": "200",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": "",
+                        "description": "Finished successfully",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-06T10:42:06",
+                        "service": "compute",
+                        "status": "200",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
         elif taskid == "cancel_job_id_permission_fail":
             ret = {
-                "task": {
-                    "data": "User does not have permission to cancel job",
-                    "description": "Finished with errors",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-06T10:32:26",
-                    "service": "compute",
-                    "status": "400",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": "User does not have permission to cancel job",
+                        "description": "Finished with errors",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-06T10:32:26",
+                        "service": "compute",
+                        "status": "400",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
         else:
             ret = {
-                "task": {
-                    "data": "scancel: error: Invalid job id tg",
-                    "description": "Finished with errors",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-06T10:39:47",
-                    "service": "compute",
-                    "status": "400",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": "scancel: error: Invalid job id tg",
+                        "description": "Finished with errors",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-06T10:39:47",
+                        "service": "compute",
+                        "status": "400",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
@@ -839,7 +873,7 @@ def fc_server(httpserver):
     ).respond_with_handler(cancel_handler)
 
     httpserver.expect_request(
-        re.compile("^/tasks/.*"), method="GET"
+        "/tasks", method="GET"
     ).respond_with_handler(tasks_handler)
 
     return httpserver

--- a/tests/test_compute_async.py
+++ b/tests/test_compute_async.py
@@ -89,7 +89,7 @@ def fc_server(httpserver):
     ).respond_with_handler(basic_compute.cancel_handler)
 
     httpserver.expect_request(
-        re.compile("^/tasks/.*"), method="GET"
+        "/tasks", method="GET"
     ).respond_with_handler(basic_compute.tasks_handler)
 
     return httpserver

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -124,59 +124,59 @@ def tasks_handler(request: Request):
             content_type="application/json",
         )
 
-    ret = {
-        "tasks": {
-            "taskid_1": {
-                "created_at": "2022-08-16T07:18:54",
-                "data": "data",
-                "description": "description",
-                "hash_id": "taskid_1",
-                "last_modify": "2022-08-16T07:18:54",
-                "service": "storage",
-                "status": "114",
-                "task_id": "taskid_1",
-                "task_url": "TASK_IP/tasks/taskid_1",
-                "updated_at": "2022-08-16T07:18:54",
-                "user": "username",
-            },
-            "taskid_2": {
-                "created_at": "2022-08-16T07:18:54",
-                "data": "data",
-                "description": "description",
-                "hash_id": "taskid_2",
-                "last_modify": "2022-08-16T07:18:54",
-                "service": "storage",
-                "status": "112",
-                "task_id": "taskid_2",
-                "task_url": "TASK_IP/tasks/taskid_2",
-                "updated_at": "2022-08-16T07:18:54",
-                "user": "username",
-            },
-            "taskid_3": {
-                "created_at": "2022-08-16T07:18:54",
-                "data": "data",
-                "description": "description",
-                "hash_id": "taskid_3",
-                "last_modify": "2022-08-16T07:18:54",
-                "service": "storage",
-                "status": "111",
-                "task_id": "taskid_3",
-                "task_url": "TASK_IP/tasks/taskid_3",
-                "updated_at": "2022-08-16T07:18:54",
-                "user": "username",
-            },
+    all_tasks = {
+        "taskid_1": {
+            "created_at": "2022-08-16T07:18:54",
+            "data": "data",
+            "description": "description",
+            "hash_id": "taskid_1",
+            "last_modify": "2022-08-16T07:18:54",
+            "service": "storage",
+            "status": "114",
+            "task_id": "taskid_1",
+            "task_url": "TASK_IP/tasks/taskid_1",
+            "updated_at": "2022-08-16T07:18:54",
+            "user": "username",
+        },
+        "taskid_2": {
+            "created_at": "2022-08-16T07:18:54",
+            "data": "data",
+            "description": "description",
+            "hash_id": "taskid_2",
+            "last_modify": "2022-08-16T07:18:54",
+            "service": "storage",
+            "status": "112",
+            "task_id": "taskid_2",
+            "task_url": "TASK_IP/tasks/taskid_2",
+            "updated_at": "2022-08-16T07:18:54",
+            "user": "username",
+        },
+        "taskid_3": {
+            "created_at": "2022-08-16T07:18:54",
+            "data": "data",
+            "description": "description",
+            "hash_id": "taskid_3",
+            "last_modify": "2022-08-16T07:18:54",
+            "service": "storage",
+            "status": "111",
+            "task_id": "taskid_3",
+            "task_url": "TASK_IP/tasks/taskid_3",
+            "updated_at": "2022-08-16T07:18:54",
+            "user": "username",
         }
     }
     status_code = 200
-    uri = request.url
-    if not uri.endswith("/tasks/"):
-        task_id = uri.split("/")[-1]
-        if task_id in {"taskid_1", "taskid_2", "taskid_3"}:
-            ret = {"task": ret["tasks"][task_id]}
-            status_code = 200
-        else:
-            ret = {"error": f"Task {task_id} does not exist"}
-            status_code = 404
+    tasks = request.args.get("tasks")
+
+    if tasks:
+        tasks = tasks.split(",")
+        ret = {
+         "tasks": {k: v for k, v in all_tasks.items() if k in tasks}
+        }
+    else:
+        ret = {
+         "tasks": all_tasks
+        }
 
     return Response(
         json.dumps(ret), status=status_code, content_type="application/json"
@@ -186,7 +186,7 @@ def tasks_handler(request: Request):
 @pytest.fixture
 def fc_server(httpserver):
     httpserver.expect_request(
-        re.compile("^/tasks/.*"), method="GET"
+        re.compile("^/tasks"), method="GET"
     ).respond_with_handler(tasks_handler)
 
     return httpserver
@@ -345,8 +345,7 @@ def test_cli_one_task(valid_credentials):
 
 
 def test_invalid_task(valid_client):
-    with pytest.raises(firecrest.FirecrestException):
-        valid_client._tasks(["invalid_id"])
+    assert valid_client._tasks(["invalid_id"]) == {}
 
 
 def test_tasks_invalid(invalid_client):

--- a/tests/test_extras_async.py
+++ b/tests/test_extras_async.py
@@ -52,7 +52,7 @@ def invalid_client(fc_server):
 @pytest.fixture
 def fc_server(httpserver):
     httpserver.expect_request(
-        re.compile("^/tasks/.*"), method="GET"
+        "/tasks", method="GET"
     ).respond_with_handler(basic_extras.tasks_handler)
 
     return httpserver
@@ -157,8 +157,7 @@ async def test_one_task(valid_client):
 
 @pytest.mark.asyncio
 async def test_invalid_task(valid_client):
-    with pytest.raises(firecrest.FirecrestException):
-        await valid_client._tasks(["invalid_id"])
+    assert await valid_client._tasks(["invalid_id"]) == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -197,48 +197,48 @@ def storage_tasks_handler(request: Request):
     global external_download_retry
     global external_upload_retry
 
-    uri = request.url
-    taskid = uri.split("/")[-1]
-    if taskid == "tasks":
-        # TODO: return all tasks
-        pass
-    elif taskid == "internal_transfer_id":
+    taskid = request.args.get("tasks")
+    if taskid == "internal_transfer_id":
         if internal_transfer_retry < internal_transfer_result:
             internal_transfer_retry += 1
             ret = {
-                "task": {
-                    "data": "https://127.0.0.1:5003",
-                    "description": "Queued",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-04T11:52:10",
-                    "service": "compute",
-                    "status": "100",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": "https://127.0.0.1:5003",
+                        "description": "Queued",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-04T11:52:10",
+                        "service": "compute",
+                        "status": "100",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
         else:
             ret = {
-                "task": {
-                    "data": {
-                        "job_data_err": "",
-                        "job_data_out": "",
-                        "job_file": f"/path/to/firecrest/{taskid}/sbatch-job.sh",
-                        "job_file_err": f"/path/to/firecrest/{taskid}/job-35363861.err",
-                        "job_file_out": f"/path/to/firecrest/{taskid}/job-35363861.out",
-                        "jobid": 35363861,
-                        "result": "Job submitted",
-                    },
-                    "description": "Finished successfully",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-06T13:48:52",
-                    "service": "compute",
-                    "status": "200",
-                    "task_id": "6f514b060ca036917f4194964b6e949c",
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": {
+                            "job_data_err": "",
+                            "job_data_out": "",
+                            "job_file": f"/path/to/firecrest/{taskid}/sbatch-job.sh",
+                            "job_file_err": f"/path/to/firecrest/{taskid}/job-35363861.err",
+                            "job_file_out": f"/path/to/firecrest/{taskid}/job-35363861.out",
+                            "jobid": 35363861,
+                            "result": "Job submitted",
+                        },
+                        "description": "Finished successfully",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-06T13:48:52",
+                        "service": "compute",
+                        "status": "200",
+                        "task_id": "6f514b060ca036917f4194964b6e949c",
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
@@ -246,66 +246,74 @@ def storage_tasks_handler(request: Request):
         if external_download_retry < 1:
             external_download_retry += 1
             ret = {
-                "task": {
-                    "data": "Queued",
-                    "description": "Queued",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-04T11:52:10",
-                    "service": "storage",
-                    "status": "100",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": "Queued",
+                        "description": "Queued",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-04T11:52:10",
+                        "service": "storage",
+                        "status": "100",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
         elif external_download_retry < 2:
             external_download_retry += 1
             ret = {
-                "task": {
-                    "data": "Started upload from filesystem to Object Storage",
-                    "description": "Started upload from filesystem to Object Storage",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-04T11:52:10",
-                    "service": "storage",
-                    "status": "116",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": "Started upload from filesystem to Object Storage",
+                        "description": "Started upload from filesystem to Object Storage",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-04T11:52:10",
+                        "service": "storage",
+                        "status": "116",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
         elif taskid == "external_download_id_legacy":
             ret = {
-                "task": {
-                    "data": "https://object_storage_link_legacy.com",
-                    "description": "Started upload from filesystem to Object Storage",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-04T11:52:10",
-                    "service": "storage",
-                    "status": "117",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": "https://object_storage_link_legacy.com",
+                        "description": "Started upload from filesystem to Object Storage",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-04T11:52:10",
+                        "service": "storage",
+                        "status": "117",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
         else:
             ret = {
-                "task": {
-                    "data": {
-                        "source": "/path/to/remote/source",
-                        "system_name": "machine",
-                        "url": "https://object_storage_link.com",
-                    },
-                    "description": "Started upload from filesystem to Object Storage",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-04T11:52:10",
-                    "service": "storage",
-                    "status": "117",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": {
+                            "source": "/path/to/remote/source",
+                            "system_name": "machine",
+                            "url": "https://object_storage_link.com",
+                        },
+                        "description": "Started upload from filesystem to Object Storage",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-04T11:52:10",
+                        "service": "storage",
+                        "status": "117",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
@@ -313,88 +321,94 @@ def storage_tasks_handler(request: Request):
         if external_upload_retry < 1:
             external_upload_retry += 1
             ret = {
-                "task": {
-                    "data": "Queued",
-                    "description": "Queued",
-                    "hash_id": taskid,
-                    "last_modify": "2021-12-04T11:52:10",
-                    "service": "storage",
-                    "status": "100",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "user": "username",
+                "tasks": {
+                    taskid: {
+                        "data": "Queued",
+                        "description": "Queued",
+                        "hash_id": taskid,
+                        "last_modify": "2021-12-04T11:52:10",
+                        "service": "storage",
+                        "status": "100",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "user": "username",
+                    }
                 }
             }
             status_code = 200
         elif external_upload_retry < 2:
             external_upload_retry += 1
             ret = {
-                "task": {
-                    "created_at": "2022-11-23T09:07:50",
-                    "data": {
+                "tasks": {
+                    taskid: {
+                        "created_at": "2022-11-23T09:07:50",
+                        "data": {
+                            "hash_id": taskid,
+                            "msg": "Waiting for Presigned URL to upload file to staging area (OpenStack Swift)",
+                            "source": "/path/to/local/source",
+                            "status": "110",
+                            "system_addr": "machine_addr",
+                            "system_name": "cluster1",
+                            "target": "/path/to/remote/destination",
+                            "trace_id": "trace",
+                            "user": "username",
+                        },
+                        "description": "Waiting for Form URL from Object Storage to be retrieved",
                         "hash_id": taskid,
-                        "msg": "Waiting for Presigned URL to upload file to staging area (OpenStack Swift)",
-                        "source": "/path/to/local/source",
+                        "last_modify": "2022-11-23T09:07:50",
+                        "service": "storage",
                         "status": "110",
-                        "system_addr": "machine_addr",
-                        "system_name": "cluster1",
-                        "target": "/path/to/remote/destination",
-                        "trace_id": "trace",
+                        "task_id": "taskid",
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "updated_at": "2022-11-23T09:07:50",
                         "user": "username",
-                    },
-                    "description": "Waiting for Form URL from Object Storage to be retrieved",
-                    "hash_id": taskid,
-                    "last_modify": "2022-11-23T09:07:50",
-                    "service": "storage",
-                    "status": "110",
-                    "task_id": "taskid",
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "updated_at": "2022-11-23T09:07:50",
-                    "user": "username",
+                    }
                 }
             }
             status_code = 200
         else:
             ret = {
-                "task": {
-                    "created_at": "2022-11-23T09:18:43",
-                    "data": {
-                        "hash_id": taskid,
-                        "msg": {
-                            "command": f"curl --show-error -s -ihttps://object.com/v1/AUTH_auth/username/{taskid}/ -X POST -F max_file_size=536870912000 -F max_file_count=1 -F expires=1671787123 -F signature=sign -F redirect= -F file=@/path/to/local/source ",
-                            "parameters": {
-                                "data": {
-                                    "expires": 1671787123,
-                                    "max_file_count": 1,
-                                    "max_file_size": 536870912000,
-                                    "redirect": "",
-                                    "signature": "sign",
+                "tasks": {
+                    taskid: {
+                        "created_at": "2022-11-23T09:18:43",
+                        "data": {
+                            "hash_id": taskid,
+                            "msg": {
+                                "command": f"curl --show-error -s -ihttps://object.com/v1/AUTH_auth/username/{taskid}/ -X POST -F max_file_size=536870912000 -F max_file_count=1 -F expires=1671787123 -F signature=sign -F redirect= -F file=@/path/to/local/source ",
+                                "parameters": {
+                                    "data": {
+                                        "expires": 1671787123,
+                                        "max_file_count": 1,
+                                        "max_file_size": 536870912000,
+                                        "redirect": "",
+                                        "signature": "sign",
+                                    },
+                                    "files": "/path/to/local/source",
+                                    "headers": {},
+                                    "json": {},
+                                    "method": "POST",
+                                    "params": {},
+                                    "url": f"https://object.com/v1/AUTH_auth/username/{taskid}/",
                                 },
-                                "files": "/path/to/local/source",
-                                "headers": {},
-                                "json": {},
-                                "method": "POST",
-                                "params": {},
-                                "url": f"https://object.com/v1/AUTH_auth/username/{taskid}/",
                             },
+                            "source": "/path/to/local/source",
+                            "status": "111",
+                            "system_addr": "machine_addr",
+                            "system_name": "cluster1",
+                            "target": "/path/to/remote/destination",
+                            "trace_id": "trace",
+                            "user": "username",
                         },
-                        "source": "/path/to/local/source",
+                        "description": "Form URL from Object Storage received",
+                        "hash_id": taskid,
+                        "last_modify": "2022-11-23T09:18:43",
+                        "service": "storage",
                         "status": "111",
-                        "system_addr": "machine_addr",
-                        "system_name": "cluster1",
-                        "target": "/path/to/remote/destination",
-                        "trace_id": "trace",
+                        "task_id": taskid,
+                        "task_url": f"TASK_IP/tasks/{taskid}",
+                        "updated_at": "2022-11-23T09:18:43",
                         "user": "username",
-                    },
-                    "description": "Form URL from Object Storage received",
-                    "hash_id": taskid,
-                    "last_modify": "2022-11-23T09:18:43",
-                    "service": "storage",
-                    "status": "111",
-                    "task_id": taskid,
-                    "task_url": f"TASK_IP/tasks/{taskid}",
-                    "updated_at": "2022-11-23T09:18:43",
-                    "user": "username",
+                    }
                 }
             }
             status_code = 200
@@ -411,7 +425,7 @@ def fc_server(httpserver):
     ).respond_with_handler(internal_transfer_handler)
 
     httpserver.expect_request(
-        re.compile("^/tasks/.*"), method="GET"
+        "/tasks", method="GET"
     ).respond_with_handler(storage_tasks_handler)
 
     httpserver.expect_request(

--- a/tests/test_storage_async.py
+++ b/tests/test_storage_async.py
@@ -56,7 +56,7 @@ def fc_server(httpserver):
     ).respond_with_handler(basic_storage.internal_transfer_handler)
 
     httpserver.expect_request(
-        re.compile("^/tasks/.*"), method="GET"
+        "/tasks", method="GET"
     ).respond_with_handler(basic_storage.storage_tasks_handler)
 
     httpserver.expect_request(


### PR DESCRIPTION
Two important differences in this PR:
- All the tasks methods call the `/tasks` endpoint with the `tasks` param, instead of `/tasks/<taskid>`.
- The async client will hold a set of taksids and try to merge the requests that are made to the `/tasks` endpoint, when possible.
- Requests are merged for the `poll` and `poll-active` methods.