### PR TITLE
Migrating to `build.os` in readthedocs configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,14 @@
-# .readthedocs.yml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
+
 python:
-  version: "3.8"
   install:
     - method: pip
       path: .


### PR DESCRIPTION
Fixes this: https://blog.readthedocs.com/use-build-os-config/