### PR TITLE
Support partial results in job polling methods (`page_size` and `page_number` arguments are added)

### DIFF
--- a/firecrest/AsyncClient.py
+++ b/firecrest/AsyncClient.py
@@ -1098,10 +1098,10 @@ class AsyncFirecrest:
             params["endtime"] = end_time
 
         if page_size is not None:
-            params["pageSize"] = page_size
+            params["pageSize"] = str(page_size)
 
         if page_number is not None:
-            params["pageNumber"] = page_number
+            params["pageNumber"] = str(page_number)
 
         resp = await self._get_request(
             endpoint="/compute/acct",
@@ -1147,10 +1147,10 @@ class AsyncFirecrest:
             params["jobs"] = ",".join([str(j) for j in jobids])
 
         if page_size is not None:
-            params["pageSize"] = page_size
+            params["pageSize"] = str(page_size)
 
         if page_number is not None:
-            params["pageNumber"] = page_number
+            params["pageNumber"] = str(page_number)
 
         resp = await self._get_request(
             endpoint="/compute/jobs",

--- a/firecrest/AsyncClient.py
+++ b/firecrest/AsyncClient.py
@@ -1070,6 +1070,8 @@ class AsyncFirecrest:
         jobs: Optional[Sequence[str | int]] = None,
         start_time: Optional[str] = None,
         end_time: Optional[str] = None,
+        page_size: Optional[int] = None,
+        page_number: Optional[int] = None,
     ) -> List[t.JobAcct]:
         """Retrieves information about submitted jobs.
         This call uses the `sacct` command.
@@ -1078,6 +1080,8 @@ class AsyncFirecrest:
         :param jobs: list of the IDs of the jobs
         :param start_time: Start time (and/or date) of job's query. Allowed formats are HH:MM[:SS] [AM|PM] MMDD[YY] or MM/DD[/YY] or MM.DD[.YY] MM/DD[/YY]-HH:MM[:SS] YYYY-MM-DD[THH:MM[:SS]]
         :param end_time: End time (and/or date) of job's query. Allowed formats are HH:MM[:SS] [AM|PM] MMDD[YY] or MM/DD[/YY] or MM.DD[.YY] MM/DD[/YY]-HH:MM[:SS] YYYY-MM-DD[THH:MM[:SS]]
+        :param page_size: number of entries returned (when `page_number` is not `None`, the default value is 25)
+        :param page_number: page number (if set to `None` the default value is 0)
         :calls: GET `/compute/acct`
 
                 GET `/tasks/{taskid}`
@@ -1092,6 +1096,12 @@ class AsyncFirecrest:
 
         if end_time:
             params["endtime"] = end_time
+
+        if page_size is not None:
+            params["pageSize"] = page_size
+
+        if page_number is not None:
+            params["pageNumber"] = page_number
 
         resp = await self._get_request(
             endpoint="/compute/acct",
@@ -1113,13 +1123,19 @@ class AsyncFirecrest:
             return res
 
     async def poll_active(
-        self, machine: str, jobs: Optional[Sequence[str | int]] = None
+        self,
+        machine: str,
+        jobs: Optional[Sequence[str | int]] = None,
+        page_size: Optional[int] = None,
+        page_number: Optional[int] = None,
     ) -> List[t.JobQueue]:
         """Retrieves information about active jobs.
         This call uses the `squeue -u <username>` command.
 
         :param machine: the machine name where the scheduler belongs to
         :param jobs: list of the IDs of the jobs
+        :param page_size: number of entries returned (when `page_number` is not `None`, the default value is 25)
+        :param page_number: page number (if set to `None` the default value is 0)
         :calls: GET `/compute/jobs`
 
                 GET `/tasks/{taskid}`
@@ -1128,7 +1144,13 @@ class AsyncFirecrest:
         jobids = {str(j) for j in jobs}
         params = {}
         if jobs:
-            params = {"jobs": ",".join([str(j) for j in jobids])}
+            params["jobs"] = ",".join([str(j) for j in jobids])
+
+        if page_size is not None:
+            params["pageSize"] = page_size
+
+        if page_number is not None:
+            params["pageNumber"] = page_number
 
         resp = await self._get_request(
             endpoint="/compute/jobs",


### PR DESCRIPTION
This will work for FirecREST >=1.14.0.