### PR TITLE
Reset file pointer before retrying to upload a file, after rate limit is reached

### DIFF
--- a/firecrest/AsyncClient.py
+++ b/firecrest/AsyncClient.py
@@ -91,6 +91,12 @@ class AsyncFirecrest:
         async def wrapper(*args, **kwargs):
             client = args[0]
             num_retries = 0
+            try:
+                f = kwargs["files"]["file"]
+                file_original_position = f[1].tell() if isinstance(f, tuple) else f.tell()
+            except KeyError:
+                file_original_position = None
+
             resp = await func(*args, **kwargs)
             while True:
                 if resp.status_code != client.TOO_MANY_REQUESTS_CODE:
@@ -110,6 +116,20 @@ class AsyncFirecrest:
                         default=resp.headers.get("RateLimit-Reset", default=10),
                     )
                     reset = int(reset)
+                    try:
+                        f = kwargs["files"]["file"]
+                        logger.debug(
+                            f"Resetting the file pointer of the uploaded file "
+                            f"to {file_original_position}"
+                        )
+                        if isinstance(f, tuple):
+                            f[1].seek(file_original_position)
+                        else:
+                            f.seek(file_original_position)
+
+                    except KeyError:
+                        pass
+
                     microservice = kwargs["endpoint"].split("/")[1]
                     client = args[0]
                     logger.info(


### PR DESCRIPTION
When the rate limit is reached we need to reset the file pointer of the files before making the request, otherwise an empty file is uploaded to FirecREST. This bug affected the job submission and simple upload.