### PR TITLE
First input of urllib.request.urlopen could only be of type 'str' or a Request object.

### DIFF
--- a/firecrest/AsyncExternalStorage.py
+++ b/firecrest/AsyncExternalStorage.py
@@ -249,5 +249,5 @@ class AsyncExternalDownload(AsyncExternalStorage):
             if isinstance(target_path, str) or isinstance(target_path, pathlib.Path)
             else nullcontext(target_path)
         )
-        with urllib.request.urlopen(url) as response, context as out_file:
+        with urllib.request.urlopen(url['url']) as response, context as out_file:
             shutil.copyfileobj(response, out_file)

--- a/firecrest/AsyncExternalStorage.py
+++ b/firecrest/AsyncExternalStorage.py
@@ -229,7 +229,7 @@ class AsyncExternalDownload(AsyncExternalStorage):
         :calls: GET `/tasks/{taskid}`
         """
         if self._client._api_version > Version("1.13.0"):
-            return await self.object_storage_data["url"]
+            return (await self.object_storage_data)["url"]
         else:
             return await self.object_storage_data
 
@@ -240,7 +240,7 @@ class AsyncExternalDownload(AsyncExternalStorage):
 
         :param target_path: the local path to save the file
         """
-        url = await self.object_storage_data
+        url = await self.object_storage_link
         logger.info(f"Downloading the file from {url} and saving to {target_path}")
         # LOCAL FIX FOR MAC
         # url = url.replace("192.168.220.19", "localhost")
@@ -249,5 +249,5 @@ class AsyncExternalDownload(AsyncExternalStorage):
             if isinstance(target_path, str) or isinstance(target_path, pathlib.Path)
             else nullcontext(target_path)
         )
-        with urllib.request.urlopen(url['url']) as response, context as out_file:
+        with urllib.request.urlopen(url) as response, context as out_file:
             shutil.copyfileobj(response, out_file)


### PR DESCRIPTION
Right now, `url` in `AsyncExternalDownload` is of type dictionary, which leads to the following error:

AttributeError: 'dict' object has no attribute 'timeout'
See: https://docs.python.org/3/library/urllib.request.html#module-urllib.request