### PR TITLE
Provide methods for closing and create the httpx session in AsyncFirecrest

### DIFF
--- a/firecrest/AsyncClient.py
+++ b/firecrest/AsyncClient.py
@@ -228,6 +228,11 @@ class AsyncFirecrest:
 
         self._session = httpx.AsyncClient()
 
+    @property
+    def is_session_closed(self) -> bool:
+        """Check if the httpx session is closed"""
+        return self._session.is_closed
+
     @_retry_requests  # type: ignore
     async def _get_request(
         self, endpoint, additional_headers=None, params=None

--- a/firecrest/AsyncClient.py
+++ b/firecrest/AsyncClient.py
@@ -217,6 +217,17 @@ class AsyncFirecrest:
         """
         self._api_version = parse(api_version)
 
+    async def close_session(self) -> None:
+        """Close the httpx session"""
+        await self._session.aclose()
+
+    async def create_new_session(self) -> None:
+        """Create a new httpx session"""
+        if not self._session.is_closed:
+            await self._session.aclose()
+
+        self._session = httpx.AsyncClient()
+
     @_retry_requests  # type: ignore
     async def _get_request(
         self, endpoint, additional_headers=None, params=None


### PR DESCRIPTION
One of the issues mentioned in https://github.com/eth-cscs/pyfirecrest/issues/94 .

The code that was failing could look like that:

```python
...
async def get_systems():
    await _client.create_new_session()
    systems = await _client.all_services()
    await _client.close_session()

asyncio.run(get_systems())
asyncio.run(get_systems())
```