### PR TITLE
temporarly fix for previously fixed bug

### DIFF
--- a/firecrest/path.py
+++ b/firecrest/path.py
@@ -516,7 +516,7 @@ class FcPath(os.PathLike):
         try:
             with self.convert_header_exceptions(
                 {
-                    "X-A-Directory": FileExistsError  # Note see: https://github.com/eth-cscs/firecrest/issues/172
+                    "X-Invalid-Path": FileExistsError  # Note see: https://github.com/eth-cscs/firecrest/issues/172
                 }
             ):
                 self._client.mkdir(self._machine, self.path, p=parents)


### PR DESCRIPTION
FirecREST is used to raise a wrong exception from `utilities/mkdir` on existing folder.
This was fixed in [#172](https://github.com/eth-cscs/firecrest/issues/172), however, now instead of  `X-Exists`, which is the expected response, it returns `X-Invalid-Path` (see the new issue [#202](https://github.com/eth-cscs/firecrest/issues/202) )

This PR will update the outdated wrong header exception, to the new wrong header exception :laughing: 
The purpose is to make things function, until issue [#202](https://github.com/eth-cscs/firecrest/issues/202) is solved on FirecREST.

Once that issue is resolved, the header exception should change appropriately to `X-Exists`
