### PR TITLE
Remove the trailing slash in `firecrest_url` if any

### DIFF
--- a/firecrest/v1/AsyncClient.py
+++ b/firecrest/v1/AsyncClient.py
@@ -177,7 +177,7 @@ class AsyncFirecrest:
         verify: str | bool | ssl.SSLContext = True,
         sa_role: str = "firecrest-sa",
     ) -> None:
-        self._firecrest_url = firecrest_url
+        self._firecrest_url = firecrest_url.rstrip('/')
         self._authorization = authorization
         # This should be used only for blocking operations that require multiple requests,
         # not for external upload/download

--- a/firecrest/v1/BasicClient.py
+++ b/firecrest/v1/BasicClient.py
@@ -135,7 +135,7 @@ class Firecrest:
         verify: Optional[str | bool] = None,
         sa_role: str = "firecrest-sa",
     ) -> None:
-        self._firecrest_url = firecrest_url
+        self._firecrest_url = firecrest_url.rstrip('/')
         self._authorization = authorization
         # This should be used only for blocking operations that require
         # multiple requests, not for external upload/download

--- a/firecrest/v2/_async/Client.py
+++ b/firecrest/v2/_async/Client.py
@@ -276,7 +276,7 @@ class AsyncFirecrest:
         authorization: Any,
         verify: str | bool | ssl.SSLContext = True,
     ) -> None:
-        self._firecrest_url = firecrest_url
+        self._firecrest_url = firecrest_url.rstrip('/')
         self._authorization = authorization
         self._verify = verify
         #: This attribute will be passed to all the requests that will be made.

--- a/firecrest/v2/_sync/Client.py
+++ b/firecrest/v2/_sync/Client.py
@@ -269,7 +269,7 @@ class Firecrest:
         authorization: Any,
         verify: str | bool | ssl.SSLContext = True,
     ) -> None:
-        self._firecrest_url = firecrest_url
+        self._firecrest_url = firecrest_url.rstrip('/')
         self._authorization = authorization
         self._verify = verify
         #: This attribute will be passed to all the requests that will be made.


### PR DESCRIPTION
I hit this error while with v2, and sync client. (I haven't tried the other ones.)

Pyfirecrest always adds a starting slash before calling on any end point
However, if the `firecrest_url` is set as `http://localhost:8000/`
Then it ends up in double slash situation, for example:
"http://localhost:8000//filesystem/{system_name}/ops/mkdir"