### PR TITLE
Export API explicitly

### DIFF
--- a/firecrest/__init__.py
+++ b/firecrest/__init__.py
@@ -18,7 +18,7 @@ from firecrest.FirecrestException import (
     UnexpectedStatusException,
 )
 
-__version__ = "3.2.2"
+__version__ = "3.2.3"
 __app_name__ = "firecrest"
 MIN_PYTHON_VERSION = (3, 7, 0)
 

--- a/firecrest/__init__.py
+++ b/firecrest/__init__.py
@@ -5,20 +5,6 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 #
 import sys
-
-
-__version__ = "3.2.2"
-__app_name__ = "firecrest"
-MIN_PYTHON_VERSION = (3, 7, 0)
-
-# Check python version
-if sys.version_info[:3] < MIN_PYTHON_VERSION:
-    sys.stderr.write(
-        "Unsupported Python version: "
-        "Python >= %d.%d.%d is required\n" % MIN_PYTHON_VERSION
-    )
-    sys.exit(1)
-
 from . import v1, v2
 from firecrest.Authorization import ClientCredentialsAuth
 from firecrest.FirecrestException import (
@@ -31,3 +17,31 @@ from firecrest.FirecrestException import (
     UnauthorizedException,
     UnexpectedStatusException,
 )
+
+__version__ = "3.2.2"
+__app_name__ = "firecrest"
+MIN_PYTHON_VERSION = (3, 7, 0)
+
+__all__ = [
+    "v1",
+    "v2",
+    "ClientCredentialsAuth",
+    "ClientsCredentialsException",
+    "FirecrestException",
+    "HeaderException",
+    "NotImplementedOnAPIversion",
+    "StorageDownloadException",
+    "StorageUploadException",
+    "UnauthorizedException",
+    "UnexpectedStatusException",
+    "__version__",
+    "__app_name__",
+]
+
+# Check python version
+if sys.version_info[:3] < MIN_PYTHON_VERSION:
+    sys.stderr.write(
+        "Unsupported Python version: "
+        "Python >= %d.%d.%d is required\n" % MIN_PYTHON_VERSION
+    )
+    sys.exit(1)

--- a/firecrest/v1/__init__.py
+++ b/firecrest/v1/__init__.py
@@ -15,5 +15,16 @@ from firecrest.v1.BasicClient import Firecrest
 from firecrest.v1.ExternalStorage import (
     ExternalDownload,
     ExternalUpload,
-    ExternalStorage)
+    ExternalStorage,
+)
 
+__all__ = [
+    "AsyncFirecrest",
+    "AsyncExternalDownload",
+    "AsyncExternalUpload",
+    "AsyncExternalStorage",
+    "Firecrest",
+    "ExternalDownload",
+    "ExternalUpload",
+    "ExternalStorage",
+]

--- a/firecrest/v2/__init__.py
+++ b/firecrest/v2/__init__.py
@@ -15,3 +15,12 @@ from firecrest.v2._sync.Client import (  # noqa
     ExternalUpload,
     Firecrest,
 )
+
+__all__ = [
+    "AsyncExternalDownload",
+    "AsyncExternalUpload",
+    "AsyncFirecrest",
+    "ExternalDownload",
+    "ExternalUpload",
+    "Firecrest",
+]


### PR DESCRIPTION
Explicitly add __all__ variables to make API export explicit.
Removes a few warnings, and helps linters and other static analysis tools.
    
i.e. gets rid of a warning for `from firecrest.v2 import Firecrest`
