### PR TITLE
Adapt interfaces to camelcase

### DIFF
--- a/firecrest/v2/_async/Client.py
+++ b/firecrest/v2/_async/Client.py
@@ -1702,9 +1702,14 @@ class AsyncFirecrest:
             file_path=target_path
         )
 
-        actual_transfer_method = transfer_info.get(
-            "transferDirectives", {}
-        ).get("transfer_method", "s3")
+        trans_dir = transfer_info.get("transferDirectives", {})
+        if trans_dir:
+            actual_transfer_method = trans_dir.get(
+                "transferMethod",
+                trans_dir.get("transfer_method", "s3")
+            )
+        else:
+            actual_transfer_method = "s3"
 
         if blocking:
             self.log(

--- a/firecrest/v2/_async/Client.py
+++ b/firecrest/v2/_async/Client.py
@@ -150,6 +150,11 @@ class AsyncExternalUpload(AsyncExternalTransfer):
             ).get("parts_upload_urls")
 
         if urls is None:
+            urls = self._transfer_info.get(
+                "transferDirectives", {}
+            ).get("partsUploadUrls")
+
+        if urls is None:
             raise MultipartUploadException(
                 self._transfer_info,
                 "Could not find parts upload URLs in the transfer info"
@@ -177,6 +182,11 @@ class AsyncExternalUpload(AsyncExternalTransfer):
             chunk_size = self._transfer_info.get(
                 "transferDirectives", {}
             ).get("max_part_size")
+
+        if chunk_size is None:
+            chunk_size = self._transfer_info.get(
+                "transferDirectives", {}
+            ).get("maxPartSize")
 
         if chunk_size is None:
             raise MultipartUploadException(
@@ -240,6 +250,11 @@ class AsyncExternalUpload(AsyncExternalTransfer):
             url = self._transfer_info.get(
                 "transferDirectives", {}
             ).get("complete_upload_url")
+
+        if url is None:
+            url = self._transfer_info.get(
+                "transferDirectives", {}
+            ).get("completeUploadUrl")
 
         if url is None:
             raise MultipartUploadException(
@@ -308,6 +323,11 @@ class AsyncExternalDownload(AsyncExternalTransfer):
             download_url = self._transfer_info.get(
                 "transferDirectives", {}
             ).get("download_url")
+
+        if download_url is None:
+            download_url = self._transfer_info.get(
+                "transferDirectives", {}
+            ).get("downloadUrl")
 
         if download_url is None:
             raise MultipartUploadException(
@@ -1550,9 +1570,14 @@ class AsyncFirecrest:
             local_file=local_file,
         )
 
-        actual_transfer_method = transfer_info.get(
-            "transferDirectives", {}
-        ).get("transfer_method", "s3")
+        trans_dir = transfer_info.get("transferDirectives", {})
+        if trans_dir:
+            actual_transfer_method = trans_dir.get(
+                "transferMethod",
+                trans_dir.get("transfer_method", "s3")
+            )
+        else:
+            actual_transfer_method = "s3"
 
         if blocking:
             self.log(

--- a/firecrest/v2/_sync/Client.py
+++ b/firecrest/v2/_sync/Client.py
@@ -1580,9 +1580,14 @@ class Firecrest:
             file_size=local_file_size,
         )
 
-        actual_transfer_method = transfer_info.get(
-            "transferDirectives", {}
-        ).get("transfer_method", "s3")
+        trans_dir = transfer_info.get("transferDirectives", {})
+        if trans_dir:
+            actual_transfer_method = trans_dir.get(
+                "transferMethod",
+                trans_dir.get("transfer_method", "s3")
+            )
+        else:
+            actual_transfer_method = "s3"
 
         if blocking:
             self.log(

--- a/firecrest/v2/_sync/Client.py
+++ b/firecrest/v2/_sync/Client.py
@@ -150,6 +150,11 @@ class ExternalUpload(ExternalTransfer):
             ).get("parts_upload_urls")
 
         if urls is None:
+            urls = self._transfer_info.get(
+                "transferDirectives", {}
+            ).get("partsUploadUrls")
+
+        if urls is None:
             raise MultipartUploadException(
                 self._transfer_info,
                 "Could not find parts upload URLs in the transfer info"
@@ -176,6 +181,11 @@ class ExternalUpload(ExternalTransfer):
             chunk_size = self._transfer_info.get(
                 "transferDirectives", {}
             ).get("max_part_size")
+
+        if chunk_size is None:
+            chunk_size = self._transfer_info.get(
+                "transferDirectives", {}
+            ).get("maxPartSize")
 
         if chunk_size is None:
             raise MultipartUploadException(
@@ -251,6 +261,11 @@ class ExternalUpload(ExternalTransfer):
             ).get("complete_upload_url")
 
         if url is None:
+            url = self._transfer_info.get(
+                "transferDirectives", {}
+            ).get("completeUploadUrl")
+
+        if url is None:
             raise MultipartUploadException(
                 self._transfer_info,
                 "Could not find complete upload URL in the transfer info"
@@ -317,6 +332,11 @@ class ExternalDownload(ExternalTransfer):
             download_url = self._transfer_info.get(
                 "transferDirectives", {}
             ).get("download_url")
+
+        if download_url is None:
+            download_url = self._transfer_info.get(
+                "transferDirectives", {}
+            ).get("downloadUrl")
 
         if download_url is None:
             raise MultipartUploadException(
@@ -1690,9 +1710,14 @@ class Firecrest:
             file_path=target_path
         )
 
-        actual_transfer_method = transfer_info.get(
-            "transferDirectives", {}
-        ).get("transfer_method", "s3")
+        trans_dir = transfer_info.get("transferDirectives", {})
+        if trans_dir:
+            actual_transfer_method = trans_dir.get(
+                "transferMethod",
+                trans_dir.get("transfer_method", "s3")
+            )
+        else:
+            actual_transfer_method = "s3"
 
         if blocking:
             self.log(


### PR DESCRIPTION
After version [2.5.0](https://github.com/eth-cscs/firecrest-v2/releases/tag/2.5.0) (PR: https://github.com/eth-cscs/firecrest-v2/pull/180), the responses will include only camelcase fields.