### PR TITLE
Add TokenCommandAuth and --token-command CLI option for flexible authentication

### DIFF
--- a/firecrest/Authorization.py
+++ b/firecrest/Authorization.py
@@ -130,7 +130,7 @@ class TokenCommandAuth:
         """Run the configured command and return its stdout as the access token."""
         result = subprocess.run(
             self._command,
-            shell=True,
+            shell=True,  # nosec B602 - shell=True is intentional: the command is user-supplied and user-controlled
             capture_output=True,
             text=True,
         )

--- a/firecrest/Authorization.py
+++ b/firecrest/Authorization.py
@@ -6,6 +6,7 @@
 #
 import logging
 import requests
+import subprocess
 import time
 
 import firecrest.FirecrestException as fe
@@ -108,3 +109,38 @@ class ClientCredentialsAuth:
             f"Token expires at {datetime.fromtimestamp(self._token_expiration_ts)}"
         )
         return self._access_token
+
+
+class TokenCommandAuth:
+    """
+    Authorization class that obtains a token by running a shell command.
+
+    The command is executed on every call to :meth:`get_access_token`, so it
+    naturally handles token refresh. The token is read from the command's
+    stdout (stripped of surrounding whitespace).
+
+    :param command: Shell command whose stdout is the bearer token.
+    :type command: str
+    """
+
+    def __init__(self, command: str):
+        self._command = command
+
+    def get_access_token(self) -> str:
+        """Run the configured command and return its stdout as the access token."""
+        result = subprocess.run(
+            self._command,
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Token command failed (exit {result.returncode}): {result.stderr.strip()}"
+            )
+
+        token = result.stdout.strip()
+        if not token:
+            raise RuntimeError("Token command produced no output")
+
+        return token

--- a/firecrest/__init__.py
+++ b/firecrest/__init__.py
@@ -6,7 +6,7 @@
 #
 import sys
 from . import v1, v2
-from firecrest.Authorization import ClientCredentialsAuth
+from firecrest.Authorization import ClientCredentialsAuth, TokenCommandAuth
 from firecrest.FirecrestException import (
     ClientsCredentialsException,
     FirecrestException,
@@ -26,6 +26,7 @@ __all__ = [
     "v1",
     "v2",
     "ClientCredentialsAuth",
+    "TokenCommandAuth",
     "ClientsCredentialsException",
     "FirecrestException",
     "HeaderException",

--- a/firecrest/cli2/__init__.py
+++ b/firecrest/cli2/__init__.py
@@ -970,16 +970,21 @@ def main(
     firecrest_url: str = typer.Option(
         ..., help="FirecREST URL.", envvar="FIRECREST_URL"
     ),
-    client_id: str = typer.Option(
-        ..., help="Registered client ID.", envvar="FIRECREST_CLIENT_ID"
+    client_id: Optional[str] = typer.Option(
+        None, help="Registered client ID.", envvar="FIRECREST_CLIENT_ID"
     ),
-    client_secret: str = typer.Option(
-        ..., help="Secret for the client.", envvar="FIRECREST_CLIENT_SECRET"
+    client_secret: Optional[str] = typer.Option(
+        None, help="Secret for the client.", envvar="FIRECREST_CLIENT_SECRET"
     ),
-    token_url: str = typer.Option(
-        ...,
+    token_url: Optional[str] = typer.Option(
+        None,
         help="URL of the token request in the authorization server (e.g. https://auth.com/auth/.../openid-connect/token).",
         envvar="AUTH_TOKEN_URL",
+    ),
+    token_command: Optional[str] = typer.Option(
+        None,
+        help="Shell command whose stdout is used as the bearer token. Mutually exclusive with --client-id/--client-secret/--token-url.",
+        envvar="FIRECREST_TOKEN_COMMAND",
     ),
     api_version: str = typer.Option(
         None,
@@ -1003,17 +1008,55 @@ def main(
     """
     CLI for FirecREST
 
-    Before running you need to setup the following variables or pass them as required options:
-    - FIRECREST_URL: FirecREST URL
-    - FIRECREST_CLIENT_ID: registered client ID
-    - FIRECREST_CLIENT_SECRET: secret for the client
-    - AUTH_TOKEN_URL: URL for the token request in the authorization server (e.g. https://auth.your-server.com/auth/.../openid-connect/token)
+    Authentication — choose one mode:
+
+    \b
+    Client credentials (default):
+      Set FIRECREST_CLIENT_ID, FIRECREST_CLIENT_SECRET, and AUTH_TOKEN_URL
+      (or pass --client-id, --client-secret, --token-url).
+
+    \b
+    Token command:
+      Set FIRECREST_TOKEN_COMMAND to a shell command whose stdout is the
+      bearer token (or pass --token-command). The command is re-run on
+      each request, so token refresh is handled automatically.
+      Example: --token-command "my-org-cli auth token"
     """
     _ensure_event_loop()
 
     global client
-    auth_obj = fc.ClientCredentialsAuth(client_id, client_secret, token_url)
-    auth_obj.timeout = auth_timeout
+
+    using_token_command = token_command is not None
+    using_client_creds = any([client_id, client_secret, token_url])
+
+    if using_token_command and using_client_creds:
+        raise typer.BadParameter(
+            "--token-command is mutually exclusive with --client-id, --client-secret, and --token-url"
+        )
+
+    if using_token_command:
+        auth_obj = fc.TokenCommandAuth(token_command)
+    elif using_client_creds:
+        missing = [
+            name for name, val in [
+                ("--client-id", client_id),
+                ("--client-secret", client_secret),
+                ("--token-url", token_url),
+            ] if val is None
+        ]
+        if missing:
+            raise typer.BadParameter(
+                f"Client credentials mode requires all of: --client-id, --client-secret, --token-url. "
+                f"Missing: {', '.join(missing)}"
+            )
+        auth_obj = fc.ClientCredentialsAuth(client_id, client_secret, token_url)
+        auth_obj.timeout = auth_timeout
+    else:
+        raise typer.BadParameter(
+            "No authentication method provided. Use --token-command or supply "
+            "--client-id, --client-secret, and --token-url."
+        )
+
     client = fc.v2.AsyncFirecrest(firecrest_url=firecrest_url, authorization=auth_obj)
     client.timeout = timeout
     if api_version:

--- a/firecrest/cli2/__init__.py
+++ b/firecrest/cli2/__init__.py
@@ -15,7 +15,7 @@ import yaml
 import firecrest as fc
 
 from firecrest import __app_name__, __version__
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from rich.console import Console
 from rich.logging import RichHandler
@@ -1034,7 +1034,9 @@ def main(
             "--token-command is mutually exclusive with --client-id, --client-secret, and --token-url"
         )
 
+    auth_obj: Union[fc.TokenCommandAuth, fc.ClientCredentialsAuth]
     if using_token_command:
+        assert token_command is not None
         auth_obj = fc.TokenCommandAuth(token_command)
     elif using_client_creds:
         missing = [
@@ -1049,8 +1051,10 @@ def main(
                 f"Client credentials mode requires all of: --client-id, --client-secret, --token-url. "
                 f"Missing: {', '.join(missing)}"
             )
-        auth_obj = fc.ClientCredentialsAuth(client_id, client_secret, token_url)
-        auth_obj.timeout = auth_timeout
+        assert client_id is not None and client_secret is not None and token_url is not None
+        cc_auth = fc.ClientCredentialsAuth(client_id, client_secret, token_url)
+        cc_auth.timeout = auth_timeout
+        auth_obj = cc_auth
     else:
         raise typer.BadParameter(
             "No authentication method provided. Use --token-command or supply "


### PR DESCRIPTION
The CLI now supports `--token-command` / `FIRECREST_TOKEN_COMMAND` as an alternative to client credentials. Any shell command whose stdout is a bearer token works. It is useful for personal access tokens, device flows, or org-specific token CLIs. The `TokenCommandAuth` class is also available for Python library users.

Closes #205 .