### PR TITLE
Update docs to point to Firecrest v2 in the readme and the cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ keycloak = f7t.ClientCredentialsAuth(
     client_id, client_secret, token_uri
 )
 
-# Setup the client for the specific account
-client = f7t.v1.Firecrest(
+# Setup the v2 client
+client = f7t.v2.Firecrest(
     firecrest_url="http://localhost:8000", authorization=keycloak
 )
 
 try:
-    parameters = client.parameters()
-    print(f"Firecrest parameters: {parameters}")
+    systems = client.systems()
+    print(f"Available systems: {systems}")
 except f7t.FirecrestException as e:
     # When the error comes from the responses to a firecrest request you will get a
     # `FirecrestException` and from this you can examine the http responses yourself
@@ -49,14 +49,20 @@ except Exception as e:
 
 ### How to use it from the terminal
 
-After version 1.3.0 pyFirecREST comes together with a CLI but for now it can only be used with the `f7t.ClientCredentialsAuth` authentication class.
+The CLI defaults to FirecREST v2. It supports two authentication modes.
 
-Assuming you are using the same client, you can start by setting as environment variables:
+**Client credentials** — set the following environment variables:
 ```bash
+export FIRECREST_URL=http://localhost:8000
 export FIRECREST_CLIENT_ID=firecrest-sample
 export FIRECREST_CLIENT_SECRET=b391e177-fa50-4987-beaf-e6d33ca93571
-export FIRECREST_URL=http://localhost:8000
 export AUTH_TOKEN_URL=http://localhost:8080/auth/realms/kcrealm/protocol/openid-connect/token
+```
+
+**Token command** — set a shell command whose stdout is the bearer token (re-run on each request for automatic refresh):
+```bash
+export FIRECREST_URL=http://localhost:8000
+export FIRECREST_TOKEN_COMMAND="my-org-cli auth token"
 ```
 
 After that you can explore the capabilities of the CLI with the `--help` option:
@@ -66,30 +72,25 @@ firecrest ls --help
 firecrest submit --help
 firecrest upload --help
 firecrest download --help
-firecrest submit-template --help
 ```
 
 Some basic examples:
 ```bash
-# Get the parameters of different microservices of FirecREST
-firecrest parameters
-
 # Get the available systems
 firecrest systems
 
 # Set the environment variable to specify the name of the system
 export FIRECREST_SYSTEM="cluster"
 
+# Get the user and group information for the current user on the selected system
+firecrest id
+
 # List files of directory
 firecrest ls /home
 
 # Submit a job
-firecrest submit script.sh
+firecrest submit --working-dir /home/user script.sh
 
-# Upload a "small" file (you can check the maximum size in `UTILITIES_MAX_FILE_SIZE` from the `parameters` command)
-firecrest upload --type=direct local_file.txt /path/to/cluster/fs
-
-# Upload a "large" file
-firecrest upload --type=external local_file.txt /path/to/cluster/fs
-# You will have to finish the upload with a second command that will be given in the output
+# Upload a file to the cluster filesystem
+firecrest upload local_file.txt /path/to/cluster/fs remote_file.txt
 ```

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,7 +2,7 @@
 Welcome to PyFirecREST
 ======================
 
-PyFirecREST is a Python library to use the `FirecREST API <https://firecrest.readthedocs.io>`__. With it, you can manage your resources from Python 3 scripts.
+PyFirecREST is a Python library to use the `FirecREST API v2 <https://eth-cscs.github.io/firecrest-v2/>`__. With it, you can manage your resources from Python 3 scripts.
 
 
 
@@ -25,8 +25,8 @@ You can also clone it from `Github <https://github.com/eth-cscs/pyfirecrest>`__ 
    :caption: Reference:
 
    reference_auth
-   reference_v1_index
    reference_v2_index
+   reference_v1_index
 
 
 Contact

--- a/docs/source/reference_v1_index.rst
+++ b/docs/source/reference_v1_index.rst
@@ -1,7 +1,7 @@
 API v1
 ======
 
-.. deprecated::
+.. warning::
 
     FirecREST v1 is in **maintenance mode**: only minimal-effort issue fixes will be addressed and no new features are planned.
     New projects should use :doc:`reference_v2_index` whenever possible.

--- a/docs/source/reference_v1_index.rst
+++ b/docs/source/reference_v1_index.rst
@@ -1,6 +1,11 @@
 API v1
 ======
 
+.. deprecated::
+
+    FirecREST v1 is in **maintenance mode**: only minimal-effort issue fixes will be addressed and no new features are planned.
+    New projects should use :doc:`reference_v2_index` whenever possible.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/docs/source/tutorial_basic_v1.rst
+++ b/docs/source/tutorial_basic_v1.rst
@@ -1,10 +1,10 @@
 Tutorial for FirecREST v1
 =========================
 
-.. deprecated::
+.. warning::
 
     FirecREST v1 is in **maintenance mode**: only minimal-effort issue fixes will be addressed and no new features are planned.
-    New projects should use :doc:`tutorial_basic_v2`, whenever possible.
+    New projects should use :doc:`tutorial_basic_v2` whenever possible.
 
 Your starting point to use pyFirecREST will be the creation of a FirecREST object.
 This is simply a mini client that, in cooperation with the authorization object, will take care of the necessary requests that need to be made and handle the responses.

--- a/docs/source/tutorial_basic_v1.rst
+++ b/docs/source/tutorial_basic_v1.rst
@@ -1,6 +1,11 @@
 Tutorial for FirecREST v1
 =========================
 
+.. deprecated::
+
+    FirecREST v1 is in **maintenance mode**: only minimal-effort issue fixes will be addressed and no new features are planned.
+    New projects should use :doc:`tutorial_basic_v2`, whenever possible.
+
 Your starting point to use pyFirecREST will be the creation of a FirecREST object.
 This is simply a mini client that, in cooperation with the authorization object, will take care of the necessary requests that need to be made and handle the responses.
 

--- a/docs/source/tutorial_cli.rst
+++ b/docs/source/tutorial_cli.rst
@@ -1,13 +1,43 @@
 How to use the CLI
 ==================
 
-After version 1.3.0, pyFirecREST comes together with a CLI but for now it can only be used with the ``ClientCredentialsAuth`` authentication class.
+After version 1.3.0, pyFirecREST comes together with a CLI. It supports both FirecREST v1 and v2, and defaults to **v2**.
 
-.. attention::
+You always need to set ``FIRECREST_URL`` with the URL for the FirecREST instance you are using.
+For authentication, choose one of the two modes below.
 
-    The CLI currently only supports FirecREST v1. Support for v2 is planned for the next release.
+Client credentials
+------------------
 
-You will need to set the environment variables ``FIRECREST_CLIENT_ID``, ``FIRECREST_CLIENT_SECRET`` and ``AUTH_TOKEN_URL`` to set up the Client Credentials client, as well as ``FIRECREST_URL`` with the URL for the FirecREST instance you are using.
+Set ``FIRECREST_CLIENT_ID``, ``FIRECREST_CLIENT_SECRET``, and ``AUTH_TOKEN_URL`` (or pass them as ``--client-id``, ``--client-secret``, and ``--token-url``):
+
+.. code-block:: bash
+
+    export FIRECREST_URL=https://firecrest.example.com
+    export FIRECREST_CLIENT_ID=my-client
+    export FIRECREST_CLIENT_SECRET=my-secret
+    export AUTH_TOKEN_URL=https://auth.example.com/auth/.../openid-connect/token
+
+Token command
+-------------
+
+Set ``FIRECREST_TOKEN_COMMAND`` to a shell command whose stdout is the bearer token (or pass ``--token-command``).
+The command is re-run on each request, so token refresh is handled automatically:
+
+.. code-block:: bash
+
+    export FIRECREST_URL=https://firecrest.example.com
+    export FIRECREST_TOKEN_COMMAND="my-org-cli auth token"
+
+    # Or inline:
+    firecrest --token-command "my-org-cli auth token" systems
+
+.. note::
+
+    ``--token-command`` is mutually exclusive with ``--client-id`` / ``--client-secret`` / ``--token-url``.
+
+FirecREST cli examples for v2
+-----------------------------
 
 After that you can explore the capabilities of the CLI with the `--help` option:
 
@@ -18,7 +48,6 @@ After that you can explore the capabilities of the CLI with the `--help` option:
     firecrest submit --help
     firecrest upload --help
     firecrest download --help
-    firecrest submit-template --help
 
 Some basic examples:
 
@@ -30,18 +59,14 @@ Some basic examples:
     # Set the environment variable to specify the name of the system
     export FIRECREST_SYSTEM=cluster1
 
-    # Get the parameters of different microservices of FirecREST
-    firecrest parameters
+    # Get the user and group information for the current user on the selected system
+    firecrest id
 
     # List files of directory
     firecrest ls /home
 
     # Submit a job
-    firecrest submit script.sh
+    firecrest submit --working-dir /home/user script.sh
 
-    # Upload a "small" file (you can check the maximum size in `UTILITIES_MAX_FILE_SIZE` from the `parameters` command)
-    firecrest upload --type=direct local_file.txt /path/to/cluster/fs
-
-    # Upload a "large" file
-    firecrest upload --type=external local_file.txt /path/to/cluster/fs
-    # You will have to finish the upload with a second command that will be given in the output
+    # Upload a file to the cluster filesystem
+    firecrest upload local_file.txt /path/to/cluster/fs remote_file.txt

--- a/docs/source/tutorial_index.rst
+++ b/docs/source/tutorial_index.rst
@@ -5,8 +5,8 @@ Tutorials
    :maxdepth: 2
    :caption: Contents:
 
-   tutorial_basic_v1
    tutorial_basic_v2
+   tutorial_basic_v1
    tutorial_logging
    tutorial_errors
    tutorial_cli


### PR DESCRIPTION
You can see the docs of the PR directly here: https://pyfirecrest--207.org.readthedocs.build/en/207/